### PR TITLE
Feature/auth

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,8 @@ name: KBuddy-server Jenkins
 
 on:
   push:
-    branches:
-      - main
+    branches
+      - main:
     tags:
       - "v*.*.*"  # 버전 태그를 달아 배포할 때 사용할 태그 필드
 #  pull_request:
@@ -60,7 +60,7 @@ jobs:
         with:
           images: |
             ${{ steps.get-ocir-repository.outputs.repo_path }}
-          flavor: |
+          flavor: | 
             latest=true
           tags: |
             type=sha

--- a/src/main/java/com/example/kbuddy_backend/auth/config/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/kbuddy_backend/auth/config/JwtAccessDeniedHandler.java
@@ -7,6 +7,7 @@ import com.example.kbuddy_backend.common.advice.response.CustomCode;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.util.List;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.web.access.AccessDeniedHandler;
 import org.springframework.stereotype.Component;

--- a/src/main/java/com/example/kbuddy_backend/auth/token/JwtTokenProvider.java
+++ b/src/main/java/com/example/kbuddy_backend/auth/token/JwtTokenProvider.java
@@ -53,7 +53,6 @@ public class JwtTokenProvider implements TokenProvider {
 
 
         //상담원 사용자인지 일반 사용자인지 구분하기 위한 role 추가
-
         String token = Jwts.builder()
                 .setSubject(authentication.getName())
                 .claim("role",authorities)

--- a/src/main/java/com/example/kbuddy_backend/common/advice/ControllerAdviceException.java
+++ b/src/main/java/com/example/kbuddy_backend/common/advice/ControllerAdviceException.java
@@ -12,6 +12,8 @@ import com.example.kbuddy_backend.common.advice.response.ErrorResponse;
 import com.example.kbuddy_backend.common.exception.BadRequestException;
 import com.example.kbuddy_backend.common.exception.NotFoundException;
 import com.example.kbuddy_backend.common.exception.UnauthorizedException;
+import java.util.List;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
@@ -29,10 +31,15 @@ public class ControllerAdviceException {
     //@Valid 예외
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<ErrorResponse> processValidationError(MethodArgumentNotValidException ex) {
+        // 모든 필드 오류 메시지를 리스트로 수집
+        List<String> errorMessages = ex.getBindingResult().getFieldErrors().stream()
+                .map(fieldError -> fieldError.getField() + ": " + fieldError.getDefaultMessage()) // 필드명 + 오류 메시지
+                .toList();
         return ResponseEntity.status(BAD_REQUEST)
-                .body(new ErrorResponse(ex.getBindingResult().getAllErrors().get(0).getDefaultMessage(),
-                        CustomCode.HTTP_400));
+                .body(new ErrorResponse("Validation failed for one or more fields.",
+                        CustomCode.HTTP_400, errorMessages));
     }
+
     @ExceptionHandler(NotFoundException.class)
     public ResponseEntity<ErrorResponse> handleNotFound(final Exception e) {
         log.error(e.getMessage());

--- a/src/main/java/com/example/kbuddy_backend/common/advice/ControllerAdviceException.java
+++ b/src/main/java/com/example/kbuddy_backend/common/advice/ControllerAdviceException.java
@@ -1,6 +1,7 @@
 package com.example.kbuddy_backend.common.advice;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
 import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
 import static org.springframework.http.HttpStatus.METHOD_NOT_ALLOWED;
 import static org.springframework.http.HttpStatus.NOT_FOUND;
@@ -10,6 +11,7 @@ import static org.springframework.http.HttpStatus.UNPROCESSABLE_ENTITY;
 import com.example.kbuddy_backend.common.advice.response.CustomCode;
 import com.example.kbuddy_backend.common.advice.response.ErrorResponse;
 import com.example.kbuddy_backend.common.exception.BadRequestException;
+import com.example.kbuddy_backend.common.exception.DuplicateException;
 import com.example.kbuddy_backend.common.exception.NotFoundException;
 import com.example.kbuddy_backend.common.exception.UnauthorizedException;
 import java.util.List;
@@ -38,6 +40,13 @@ public class ControllerAdviceException {
         return ResponseEntity.status(BAD_REQUEST)
                 .body(new ErrorResponse("Validation failed for one or more fields.",
                         CustomCode.HTTP_400, errorMessages));
+    }
+
+    //409에러 처리
+    @ExceptionHandler(DuplicateException.class)
+    public ResponseEntity<ErrorResponse> handleDuplicate(final Exception e) {
+        log.error(e.getMessage());
+        return ResponseEntity.status(CONFLICT).body(new ErrorResponse(e.getMessage(), CustomCode.HTTP_409));
     }
 
     @ExceptionHandler(NotFoundException.class)

--- a/src/main/java/com/example/kbuddy_backend/common/advice/ResponseWrapper.java
+++ b/src/main/java/com/example/kbuddy_backend/common/advice/ResponseWrapper.java
@@ -3,10 +3,10 @@ package com.example.kbuddy_backend.common.advice;
 import com.example.kbuddy_backend.common.advice.response.ApiResponse;
 import com.example.kbuddy_backend.common.advice.response.ErrorResponse;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.List;
 import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.HttpMessageConverter;
-import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.http.server.ServerHttpRequest;
 import org.springframework.http.server.ServerHttpResponse;
 import org.springframework.http.server.ServletServerHttpResponse;
@@ -35,6 +35,10 @@ public class ResponseWrapper implements ResponseBodyAdvice<Object> {
         if (body instanceof ErrorResponse errorResponse) {
             String code = errorResponse.getCode();
             String message = errorResponse.getMessage();
+            List<String> details = errorResponse.getDetails();
+            if(details != null) {
+                return ApiResponse.errorDetail(message, path, status, code, details);
+            }
             return ApiResponse.error(message, path, status, code);
 
         }

--- a/src/main/java/com/example/kbuddy_backend/common/advice/response/ApiResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/common/advice/response/ApiResponse.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -34,6 +35,9 @@ public class ApiResponse<T> {
     @Schema(description = "실제 응답 데이터")
     public T data;
 
+    @Schema(description = "상세 정보")
+    public List<String> details = List.of();
+
 
     public static <T> ApiResponse<T> ok(T data,String path){
         return new ApiResponse<>(200,path,data, CustomCode.HTTP_200);
@@ -47,9 +51,14 @@ public class ApiResponse<T> {
         return new ApiResponse<>(204,path,data, CustomCode.HTTP_204);
     }
 
-    public static ApiResponse<?> error(String message,String path,int status, String code){
+    public static ApiResponse<?> error(String message, String path, int status, String code){
         return new ApiResponse<>(status,path,message,code);
     }
+
+    public static ApiResponse<?> errorDetail(String message, String path, int status, String code, List<String> details){
+        return new ApiResponse<>(status,path,message,code,details);
+    }
+
     public ApiResponse(int status, String path, T message, CustomCode code) {
         this.status = status;
         this.path = path;
@@ -57,6 +66,13 @@ public class ApiResponse<T> {
         this.code = code.getCode();
     }
 
+    public ApiResponse(int status, String path, T message, String code, List<String> details) {
+        this.status = status;
+        this.path = path;
+        this.data = message;
+        this.code = code;
+        this.details = details;
+    }
     public ApiResponse(int status, String path, T message, String code) {
         this.status = status;
         this.path = path;

--- a/src/main/java/com/example/kbuddy_backend/common/advice/response/ErrorResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/common/advice/response/ErrorResponse.java
@@ -1,11 +1,13 @@
 package com.example.kbuddy_backend.common.advice.response;
 
+import java.util.List;
 import lombok.Getter;
 
 @Getter
 public class ErrorResponse {
     private final String message;
     private String code;
+    private List<String> details;
 
     public ErrorResponse(final String message) {
         this.message = message;
@@ -14,5 +16,11 @@ public class ErrorResponse {
     public ErrorResponse(final String message, final CustomCode code) {
         this.message = String.format("Error: %s", message);
         this.code = code.getCode();
+    }
+
+    public ErrorResponse(final String message, final CustomCode code, final List<String> details) {
+        this.message = String.format("Error: %s", message);
+        this.code = code.getCode();
+        this.details = details;
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/common/config/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/CurrentUserArgumentResolver.java
@@ -33,10 +33,10 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
     public User resolveArgument(MethodParameter parameter, @Nullable ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, @Nullable WebDataBinderFactory binderFactory)
             throws Exception {
-        String email = SecurityContextHolder.getContextHolderStrategy().getContext()
+        String userId = SecurityContextHolder.getContextHolderStrategy().getContext()
                 .getAuthentication().getName();
 
-        return userRepository.findByEmail(email)
+        return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/common/config/CurrentUserArgumentResolver.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/CurrentUserArgumentResolver.java
@@ -35,8 +35,9 @@ public class CurrentUserArgumentResolver implements HandlerMethodArgumentResolve
             throws Exception {
         String userId = SecurityContextHolder.getContextHolderStrategy().getContext()
                 .getAuthentication().getName();
+        System.out.println("Current User userId: " + userId);
 
-        return userRepository.findById(userId)
+        return userRepository.findById(Long.valueOf(userId))
                 .orElseThrow(UserNotFoundException::new);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/common/config/DataInitializer.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/DataInitializer.java
@@ -45,7 +45,7 @@ public class DataInitializer {
                 .lastName("stark")
                 .gender(Gender.M)
                 .bio("hello, i'm tony stark.")
-                .country(Country.KOREA)
+                .country(Country.KR)
                 .build();
         user.addAuthority(new Authority(NORMAL_USER));
         User saveUser = userRepository.save(user);

--- a/src/main/java/com/example/kbuddy_backend/common/config/DataInitializer.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/DataInitializer.java
@@ -46,6 +46,7 @@ public class DataInitializer {
                 .gender(Gender.M)
                 .bio("hello, i'm tony stark.")
                 .country(Country.KR)
+                .birthDate("000724")
                 .build();
         user.addAuthority(new Authority(NORMAL_USER));
         User saveUser = userRepository.save(user);

--- a/src/main/java/com/example/kbuddy_backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/SecurityConfig.java
@@ -56,8 +56,7 @@ public class SecurityConfig {
                         authorizeRequests
                                 .requestMatchers("/kbuddy/v1/auth/password","/kbuddy/v1/auth/authentication").authenticated()
                                 .requestMatchers("/kbuddy/v1/auth/**").permitAll()
-                                .requestMatchers("/kbuddy/v1/user/**").authenticated()
-                                .anyRequest().permitAll());
+                                .anyRequest().authenticated());
 
         return http.build();
     }

--- a/src/main/java/com/example/kbuddy_backend/common/exception/DuplicateException.java
+++ b/src/main/java/com/example/kbuddy_backend/common/exception/DuplicateException.java
@@ -1,0 +1,7 @@
+package com.example.kbuddy_backend.common.exception;
+
+public class DuplicateException extends RuntimeException{
+        public DuplicateException(String message) {
+            super(message);
+        }
+}

--- a/src/main/java/com/example/kbuddy_backend/common/exception/InvalidDateFormatException.java
+++ b/src/main/java/com/example/kbuddy_backend/common/exception/InvalidDateFormatException.java
@@ -1,0 +1,8 @@
+package com.example.kbuddy_backend.common.exception;
+
+public  class InvalidDateFormatException extends BadRequestException {
+    public InvalidDateFormatException() {
+            super("Invalid Date Format");
+        }
+    }
+

--- a/src/main/java/com/example/kbuddy_backend/common/validate/DateValidator.java
+++ b/src/main/java/com/example/kbuddy_backend/common/validate/DateValidator.java
@@ -1,0 +1,16 @@
+package com.example.kbuddy_backend.common.validate;
+
+import com.example.kbuddy_backend.common.exception.InvalidDateFormatException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+public class DateValidator {
+    public static void isValidDate(String date) {
+        try {
+            DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyMMdd");
+            LocalDate.parse(date, formatter);
+        } catch (Exception e) {
+            throw new InvalidDateFormatException();
+        }
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/user/constant/Country.java
+++ b/src/main/java/com/example/kbuddy_backend/user/constant/Country.java
@@ -1,7 +1,7 @@
 package com.example.kbuddy_backend.user.constant;
 
 public enum Country {
-	KOREA,
-	USA,
-	JAPAN,
+	KR,
+	US,
+	JP,
 }

--- a/src/main/java/com/example/kbuddy_backend/user/constant/Country.java
+++ b/src/main/java/com/example/kbuddy_backend/user/constant/Country.java
@@ -1,7 +1,42 @@
 package com.example.kbuddy_backend.user.constant;
 
 public enum Country {
-	KR,
-	US,
-	JP,
+	KR("South Korea", "KR"),
+	US("United States", "US"),
+	JP("Japan", "JP"),
+	CN("China", "CN"),
+	GB("United Kingdom", "GB"),
+	DE("Germany", "DE"),
+	FR("France", "FR"),
+	IN("India", "IN"),
+	BR("Brazil", "BR"),
+	AU("Australia", "AU"),
+	CA("Canada", "CA"),
+	IT("Italy", "IT"),
+	MX("Mexico", "MX"),
+	RU("Russia", "RU"),
+	ES("Spain", "ES"),
+	NL("Netherlands", "NL"),
+	SE("Sweden", "SE"),
+	CH("Switzerland", "CH"),
+	TR("Turkey", "TR");
+
+	private final String name; // Display name like "South Korea"
+	private final String code; // Country code like "KR"
+
+	// Constructor
+	Country(String name, String code) {
+		this.name = name;
+		this.code = code;
+	}
+
+	// Getter for the display name
+	public String getName() {
+		return name;
+	}
+
+	// Getter for the country code
+	public String getCode() {
+		return code;
+	}
 }

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -25,7 +25,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -98,7 +98,7 @@ public class UserAuthController {
     
     @PostMapping("/userId/check")
     public ResponseEntity<DefaultResponse> checkUserId(@RequestBody @Valid UserNameCheckRequest userNameCheckRequest) {
-        if (userRepository.existsByUsername(userNameCheckRequest.userName())) {
+        if (userRepository.existsByUsername(userNameCheckRequest.userId())) {
             throw new DuplicateUserIdException();
         }
         return ResponseEntity.ok().body(DefaultResponse.of(true, "사용 가능한 사용자 아이디입니다."));

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -5,6 +5,7 @@ import static org.springframework.http.HttpStatus.*;
 import com.example.kbuddy_backend.auth.dto.response.AccessTokenAndRefreshTokenResponse;
 import com.example.kbuddy_backend.auth.service.MailSendService;
 import com.example.kbuddy_backend.common.config.CurrentUser;
+import com.example.kbuddy_backend.common.validate.DateValidator;
 import com.example.kbuddy_backend.user.dto.request.EmailCheckRequest;
 import com.example.kbuddy_backend.user.dto.request.EmailRequest;
 import com.example.kbuddy_backend.user.dto.request.LoginRequest;
@@ -47,7 +48,7 @@ public class UserAuthController {
     @PostMapping("/register")
     public ResponseEntity<AccessTokenAndRefreshTokenResponse> register(
             @Valid @RequestBody final RegisterRequest registerRequest) {
-
+        DateValidator.isValidDate(registerRequest.birthDate());
         AccessTokenAndRefreshTokenResponse token = userAuthService.register(registerRequest);
         return ResponseEntity.status(CREATED).body(token);
     }
@@ -56,7 +57,7 @@ public class UserAuthController {
     @PostMapping("/oauth/register")
     public ResponseEntity<AccessTokenAndRefreshTokenResponse> oAuthRegister(
             @RequestBody @Valid final OAuthRegisterRequest registerRequest) {
-
+        DateValidator.isValidDate(registerRequest.birthDate());
         AccessTokenAndRefreshTokenResponse token = userAuthService.oAuthRegister(registerRequest);
         return ResponseEntity.status(CREATED).body(token);
     }

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -111,7 +111,7 @@ public class UserAuthController {
     @PostMapping("/email/send")
     public ResponseEntity<EmailCodeResponse> mailSend(@RequestBody @Valid EmailRequest emailRequest) {
 
-        if (userRepository.existsByEmail(emailRequest.email())) {
+        if (userRepository.existsByEmailAndOauthCategoryIsNullAndOauthUidIsNull(emailRequest.email())) {
             throw new DuplicateEmailException();
         }
 

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -95,7 +95,8 @@ public class UserAuthController {
         userAuthService.resetPassword(passwordRequest, user);
         return ResponseEntity.ok().body("비밀번호 변경 성공");
     }
-    
+
+    @Operation(summary = "사용자 아이디 중복 체크", description = "아이디/패스워드 기반 회원가입하는 사용자의 사용자 아이디의 중복여부를 체크합니다.")
     @PostMapping("/userId/check")
     public ResponseEntity<DefaultResponse> checkUserId(@RequestBody @Valid UserNameCheckRequest userNameCheckRequest) {
         if (userRepository.existsByUsername(userNameCheckRequest.userId())) {

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -5,7 +5,6 @@ import static org.springframework.http.HttpStatus.*;
 import com.example.kbuddy_backend.auth.dto.response.AccessTokenAndRefreshTokenResponse;
 import com.example.kbuddy_backend.auth.service.MailSendService;
 import com.example.kbuddy_backend.common.config.CurrentUser;
-import com.example.kbuddy_backend.common.exception.BadRequestException;
 import com.example.kbuddy_backend.user.dto.request.EmailCheckRequest;
 import com.example.kbuddy_backend.user.dto.request.EmailRequest;
 import com.example.kbuddy_backend.user.dto.request.LoginRequest;
@@ -19,18 +18,13 @@ import com.example.kbuddy_backend.user.entity.User;
 import com.example.kbuddy_backend.user.exception.DuplicateEmailException;
 import com.example.kbuddy_backend.user.repository.UserRepository;
 import com.example.kbuddy_backend.user.service.UserAuthService;
-import com.example.kbuddy_backend.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
-import org.springframework.validation.BindingResult;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -44,18 +38,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserAuthController {
 
     private final UserAuthService userAuthService;
-    private final UserService userService;
     private final MailSendService mailService;
     private final UserRepository userRepository;
 
     @Operation(summary = "아이디/패스워드 회원 가입", description = "아이디/패스워드 기반 회원가입을 합니다.")
     @PostMapping("/register")
     public ResponseEntity<AccessTokenAndRefreshTokenResponse> register(
-            @Valid @RequestBody final RegisterRequest registerRequest, BindingResult bindingResult) {
-
-        if (bindingResult.hasErrors()) {
-            throw new BadRequestException(Objects.requireNonNull(bindingResult.getFieldError()).getDefaultMessage());
-        }
+            @Valid @RequestBody final RegisterRequest registerRequest) {
 
         AccessTokenAndRefreshTokenResponse token = userAuthService.register(registerRequest);
         return ResponseEntity.status(CREATED).body(token);
@@ -79,7 +68,6 @@ public class UserAuthController {
         }
         return ResponseEntity.ok().body(DefaultResponse.of(false, "가입된 내역이 없습니다."));
     }
-
 
     @Operation(summary = "아이디/패스워드 로그인", description = "아이디/패스워드 기반 로그인을 합니다.")
     @PostMapping("/login")
@@ -138,7 +126,6 @@ public class UserAuthController {
     @GetMapping("/authentication")
     public ResponseEntity<Authentication>
     getUserAuthentication(Authentication authentication) {
-
         return ResponseEntity.ok().body(authentication);
     }
 

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -12,10 +12,12 @@ import com.example.kbuddy_backend.user.dto.request.OAuthLoginRequest;
 import com.example.kbuddy_backend.user.dto.request.OAuthRegisterRequest;
 import com.example.kbuddy_backend.user.dto.request.PasswordRequest;
 import com.example.kbuddy_backend.user.dto.request.RegisterRequest;
+import com.example.kbuddy_backend.user.dto.request.UserNameCheckRequest;
 import com.example.kbuddy_backend.user.dto.response.DefaultResponse;
 import com.example.kbuddy_backend.user.dto.response.EmailCodeResponse;
 import com.example.kbuddy_backend.user.entity.User;
 import com.example.kbuddy_backend.user.exception.DuplicateEmailException;
+import com.example.kbuddy_backend.user.exception.DuplicateUserIdException;
 import com.example.kbuddy_backend.user.repository.UserRepository;
 import com.example.kbuddy_backend.user.service.UserAuthService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,6 +25,7 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -91,9 +94,15 @@ public class UserAuthController {
                                                 User user) {
         userAuthService.resetPassword(passwordRequest, user);
         return ResponseEntity.ok().body("비밀번호 변경 성공");
-
     }
-
+    
+    @PostMapping("/userId/check")
+    public ResponseEntity<DefaultResponse> checkUserId(@RequestBody @Valid UserNameCheckRequest userNameCheckRequest) {
+        if (userRepository.existsByUsername(userNameCheckRequest.userName())) {
+            throw new DuplicateUserIdException();
+        }
+        return ResponseEntity.ok().body(DefaultResponse.of(true, "사용 가능한 사용자 아이디입니다."));
+    }
 
     /**
      * 사용 가능한 이메일인지 검사 -> 이메일 코드 전송
@@ -107,7 +116,7 @@ public class UserAuthController {
         }
 
         int code = mailService.joinEmail(emailRequest.email());
-        return ResponseEntity.ok().body(new EmailCodeResponse(emailRequest.email(),code));
+        return ResponseEntity.ok().body(new EmailCodeResponse(emailRequest.email(), code));
     }
 
     //이메일 코드 인증

--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserAuthController.java
@@ -30,6 +30,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -63,12 +64,7 @@ public class UserAuthController {
     @Operation(summary = "OAuth 회원가입", description = "OAuth(KAKAO, GOOGLE, APPLE) 기반 회원가입을 합니다.")
     @PostMapping("/oauth/register")
     public ResponseEntity<AccessTokenAndRefreshTokenResponse> oAuthRegister(
-            @RequestBody final OAuthRegisterRequest registerRequest, BindingResult bindingResult) {
-
-        if (bindingResult.hasErrors()) {
-            throw new IllegalArgumentException(
-                    Objects.requireNonNull(bindingResult.getFieldError()).getDefaultMessage());
-        }
+            @RequestBody @Valid final OAuthRegisterRequest registerRequest) {
 
         AccessTokenAndRefreshTokenResponse token = userAuthService.oAuthRegister(registerRequest);
         return ResponseEntity.status(CREATED).body(token);
@@ -77,7 +73,7 @@ public class UserAuthController {
     @Operation(summary = "OAuth 회원가입 체크", description = "OAuth로 회원가입한 내역이 있는지 검사합니다.")
     @PostMapping("/oauth/check")
     public ResponseEntity<DefaultResponse> checkOAuthUser(
-            @RequestBody final OAuthLoginRequest request) {
+            @RequestBody @Valid final OAuthLoginRequest request) {
         if (userAuthService.checkOAuthUser(request)) {
             return ResponseEntity.ok().body(DefaultResponse.of(true, "가입된 내역이 있습니다."));
         }
@@ -87,7 +83,7 @@ public class UserAuthController {
 
     @Operation(summary = "아이디/패스워드 로그인", description = "아이디/패스워드 기반 로그인을 합니다.")
     @PostMapping("/login")
-    public ResponseEntity<AccessTokenAndRefreshTokenResponse> login(@RequestBody final LoginRequest loginRequest) {
+    public ResponseEntity<AccessTokenAndRefreshTokenResponse> login(@RequestBody @Valid final LoginRequest loginRequest) {
         AccessTokenAndRefreshTokenResponse token = userAuthService.login(loginRequest);
         return ResponseEntity.ok().body(token);
     }
@@ -95,14 +91,14 @@ public class UserAuthController {
     @Operation(summary = "OAuth 로그인", description = "OAuth를 통해 로그인합니다.ㅣ")
     @PostMapping("/oauth/login")
     public ResponseEntity<AccessTokenAndRefreshTokenResponse> oAuthLogin(
-            @RequestBody final OAuthLoginRequest loginRequest) {
+            @RequestBody @Valid final OAuthLoginRequest loginRequest) {
         AccessTokenAndRefreshTokenResponse token = userAuthService.oAuthLogin(loginRequest);
         return ResponseEntity.ok().body(token);
     }
 
     @Operation(summary = "비밀번호 변경", description = "아이디/패스워드 기반 회원가입한 사용자의 비밀번호를 변경합니다.")
     @PostMapping("/password")
-    public ResponseEntity<String> resetPassword(@RequestBody final PasswordRequest passwordRequest,
+    public ResponseEntity<String> resetPassword(@RequestBody @Valid final PasswordRequest passwordRequest,
                                                 @Parameter(hidden = true) @CurrentUser
                                                 User user) {
         userAuthService.resetPassword(passwordRequest, user);

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/LoginRequest.java
@@ -1,6 +1,8 @@
 package com.example.kbuddy_backend.user.dto.request;
 
-public record LoginRequest(String email,String password) {
+import jakarta.validation.constraints.NotNull;
+
+public record LoginRequest(@NotNull String email, @NotNull String password) {
     public static LoginRequest of(String email, String password) {
         return new LoginRequest(email, password);
     }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/LoginRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/LoginRequest.java
@@ -2,8 +2,8 @@ package com.example.kbuddy_backend.user.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
-public record LoginRequest(@NotNull String email, @NotNull String password) {
-    public static LoginRequest of(String email, String password) {
-        return new LoginRequest(email, password);
+public record LoginRequest(@NotNull String emailOrUserId, @NotNull String password) {
+    public static LoginRequest of(String emailOrUserId, String password) {
+        return new LoginRequest(emailOrUserId, password);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthLoginRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthLoginRequest.java
@@ -2,9 +2,10 @@ package com.example.kbuddy_backend.user.dto.request;
 
 import com.example.kbuddy_backend.user.constant.OAuthCategory;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 
-public record OAuthLoginRequest(String oauthUid, OAuthCategory oauth) {
-    public static OAuthLoginRequest of(String oauthUid, OAuthCategory oauth) {
-        return new OAuthLoginRequest(oauthUid, oauth);
+public record OAuthLoginRequest(@NotNull String oAuthUid, @NotNull OAuthCategory oAuthCategory) {
+    public static OAuthLoginRequest of(String oAuthUid, OAuthCategory oAuthCategory) {
+        return new OAuthLoginRequest(oAuthUid, oAuthCategory);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthLoginRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthLoginRequest.java
@@ -3,8 +3,8 @@ package com.example.kbuddy_backend.user.dto.request;
 import com.example.kbuddy_backend.user.constant.OAuthCategory;
 import jakarta.validation.constraints.Email;
 
-public record OAuthLoginRequest(@Email String email, OAuthCategory oauth) {
-    public static OAuthLoginRequest of(String email, OAuthCategory oauth) {
-        return new OAuthLoginRequest(email, oauth);
+public record OAuthLoginRequest(String oauthUid, OAuthCategory oauth) {
+    public static OAuthLoginRequest of(String oauthUid, OAuthCategory oauth) {
+        return new OAuthLoginRequest(oauthUid, oauth);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthRegisterRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthRegisterRequest.java
@@ -4,13 +4,15 @@ import com.example.kbuddy_backend.user.constant.Country;
 import com.example.kbuddy_backend.user.constant.Gender;
 import com.example.kbuddy_backend.user.constant.OAuthCategory;
 import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 
 //todo: validation
-public record OAuthRegisterRequest(@Pattern(regexp = "^[a-zA-Z0-9]{3,20}$",message = "닉네임 유효성 검사 실패") String userId, @Email(message = "이메일 형식에 맞지 않습니다.") String email, String firstName, String lastName,
-								   Country country, Gender gender, String oauthUid, OAuthCategory oAuthCategory) {
+
+public record OAuthRegisterRequest(@NotNull @Pattern(regexp = "^[a-zA-Z0-9]{3,20}$",message = "닉네임 유효성 검사 실패") String userId, @NotNull @Email(message = "이메일 형식에 맞지 않습니다.") String email, @NotNull String firstName, @NotNull String lastName,
+								   @NotNull Country country, @NotNull Gender gender, @NotNull String oAuthUid, @NotNull OAuthCategory oAuthCategory) {
 	public static OAuthRegisterRequest of(String userId, String email, String firstName, String lastName,
-                                          Country country, Gender gender,String oauthUid, OAuthCategory oAuthCategory) {
-		return new OAuthRegisterRequest(userId, email, firstName, lastName, country, gender, oauthUid, oAuthCategory);
+                                          Country country, Gender gender,String oAuthUid, OAuthCategory oAuthCategory) {
+		return new OAuthRegisterRequest(userId, email, firstName, lastName, country, gender, oAuthUid, oAuthCategory);
 	}
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthRegisterRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthRegisterRequest.java
@@ -10,9 +10,9 @@ import jakarta.validation.constraints.Pattern;
 //todo: validation
 
 public record OAuthRegisterRequest(@NotNull @Pattern(regexp = "^[a-zA-Z0-9]{3,20}$",message = "닉네임 유효성 검사 실패") String userId, @NotNull @Email(message = "이메일 형식에 맞지 않습니다.") String email, @NotNull String firstName, @NotNull String lastName,
-								   @NotNull Country country, @NotNull Gender gender, @NotNull String oAuthUid, @NotNull OAuthCategory oAuthCategory) {
+								   @NotNull Country country, @NotNull Gender gender, @NotNull String birthDate,@NotNull String oAuthUid, @NotNull OAuthCategory oAuthCategory) {
 	public static OAuthRegisterRequest of(String userId, String email, String firstName, String lastName,
-                                          Country country, Gender gender,String oAuthUid, OAuthCategory oAuthCategory) {
-		return new OAuthRegisterRequest(userId, email, firstName, lastName, country, gender, oAuthUid, oAuthCategory);
+                                          Country country, Gender gender,String birthDate, String oAuthUid, OAuthCategory oAuthCategory) {
+		return new OAuthRegisterRequest(userId, email, firstName, lastName, country, gender,birthDate, oAuthUid, oAuthCategory);
 	}
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthRegisterRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/OAuthRegisterRequest.java
@@ -8,9 +8,9 @@ import jakarta.validation.constraints.Pattern;
 
 //todo: validation
 public record OAuthRegisterRequest(@Pattern(regexp = "^[a-zA-Z0-9]{3,20}$",message = "닉네임 유효성 검사 실패") String userId, @Email(message = "이메일 형식에 맞지 않습니다.") String email, String firstName, String lastName,
-								   Country country, Gender gender, OAuthCategory oauth) {
+								   Country country, Gender gender, String oauthUid, OAuthCategory oAuthCategory) {
 	public static OAuthRegisterRequest of(String userId, String email, String firstName, String lastName,
-                                          Country country, Gender gender, OAuthCategory oauth) {
-		return new OAuthRegisterRequest(userId, email, firstName, lastName, country, gender, oauth);
+                                          Country country, Gender gender,String oauthUid, OAuthCategory oAuthCategory) {
+		return new OAuthRegisterRequest(userId, email, firstName, lastName, country, gender, oauthUid, oAuthCategory);
 	}
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/PasswordRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/PasswordRequest.java
@@ -1,6 +1,8 @@
 package com.example.kbuddy_backend.user.dto.request;
 
-public record PasswordRequest(String password) {
+import jakarta.validation.constraints.NotNull;
+
+public record PasswordRequest(@NotNull String password) {
 	public static PasswordRequest of(String password) {
 		return new PasswordRequest(password);
 	}

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/RegisterRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/RegisterRequest.java
@@ -10,9 +10,9 @@ import jakarta.validation.constraints.Size;
 
 //todo: validation
 public record RegisterRequest(@NotNull @Pattern(regexp = "^[a-zA-Z0-9]{3,20}$",message = "닉네임 유효성 검사 실패") String userId, @NotNull @Email String email, @NotNull @Size(min = 8) @Pattern(regexp = "^(?=.*[!@#$%^&*()_+\\-=\\[\\]{};':\"\\\\|,.<>\\/?]).{8,}$") String password, @NotNull @Size(max = 30) @Pattern(regexp = "^[a-zA-Z]+$") String firstName, @NotNull @Size(max = 30) @Pattern(regexp = "^[a-zA-Z]+$") String lastName,
-							  @NotNull Country country, @NotNull Gender gender) {
+							  @NotNull Country country, @NotNull Gender gender, @NotNull String birthDate) {
 	public static RegisterRequest of(String userId, String email, String password, String firstName, String lastName,
-		Country country, Gender gender) {
-		return new RegisterRequest(userId, email, password, firstName, lastName, country, gender);
+		Country country, Gender gender,String birthDate) {
+		return new RegisterRequest(userId, email, password, firstName, lastName, country, gender,birthDate);
 	}
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/UserNameCheckRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/UserNameCheckRequest.java
@@ -1,0 +1,9 @@
+package com.example.kbuddy_backend.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record UserNameCheckRequest(@NotNull String userName) {
+    public static UserNameCheckRequest of(String userName) {
+        return new UserNameCheckRequest(userName);
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/user/dto/request/UserNameCheckRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/request/UserNameCheckRequest.java
@@ -2,8 +2,8 @@ package com.example.kbuddy_backend.user.dto.request;
 
 import jakarta.validation.constraints.NotNull;
 
-public record UserNameCheckRequest(@NotNull String userName) {
-    public static UserNameCheckRequest of(String userName) {
-        return new UserNameCheckRequest(userName);
+public record UserNameCheckRequest(@NotNull String userId) {
+    public static UserNameCheckRequest of(String userId) {
+        return new UserNameCheckRequest(userId);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/entity/User.java
+++ b/src/main/java/com/example/kbuddy_backend/user/entity/User.java
@@ -56,7 +56,6 @@ public class User extends BaseTimeEntity {
     private List<Authority> authorities = new ArrayList<>();
 
     @Enumerated(EnumType.STRING)
-    @Nullable
     private OAuthCategory oauthCategory;
 
     private String oauthUid;
@@ -79,8 +78,8 @@ public class User extends BaseTimeEntity {
 
     @Builder
     public User(String username, String password, String email, String firstName, String lastName, Gender gender,
-                Country country,String bio,
-                @Nullable OAuthCategory oAuthCategory, @Nullable String oauthUid) {
+                Country country, String bio,
+                @Nullable OAuthCategory oAuthCategory, @Nullable String oAuthUid) {
         this.gender = gender;
         this.country = country;
         this.firstName = firstName;
@@ -89,7 +88,7 @@ public class User extends BaseTimeEntity {
         this.username = username;
         this.password = password;
         this.bio = bio;
-        this.oauthUid = oauthUid;
+        this.oauthUid = oAuthUid;
         this.oauthCategory = oAuthCategory;
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/entity/User.java
+++ b/src/main/java/com/example/kbuddy_backend/user/entity/User.java
@@ -48,6 +48,8 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Country country;
 
+    private String birthDate;
+
     private String bio;
     private String profileImageUrl;
     private boolean isActive = true;
@@ -79,11 +81,12 @@ public class User extends BaseTimeEntity {
     @Builder
     public User(String username, String password, String email, String firstName, String lastName, Gender gender,
                 Country country, String bio,
-                @Nullable OAuthCategory oAuthCategory, @Nullable String oAuthUid) {
+                OAuthCategory oAuthCategory, String oAuthUid, String birthDate) {
         this.gender = gender;
         this.country = country;
         this.firstName = firstName;
         this.lastName = lastName;
+        this.birthDate = birthDate;
         this.email = email;
         this.username = username;
         this.password = password;

--- a/src/main/java/com/example/kbuddy_backend/user/entity/User.java
+++ b/src/main/java/com/example/kbuddy_backend/user/entity/User.java
@@ -22,7 +22,6 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.springframework.lang.Nullable;
 
 @Getter
 @Entity
@@ -35,7 +34,7 @@ public class User extends BaseTimeEntity {
     @Column(name = "user_id")
     private Long id;
 
-    private UUID uuid;
+    private final UUID uuid = UUID.randomUUID();
     private String firstName;
     private String lastName;
     private String username;

--- a/src/main/java/com/example/kbuddy_backend/user/entity/User.java
+++ b/src/main/java/com/example/kbuddy_backend/user/entity/User.java
@@ -59,6 +59,8 @@ public class User extends BaseTimeEntity {
     @Nullable
     private OAuthCategory oauthCategory;
 
+    private String oauthUid;
+
     @OneToMany(mappedBy = "user")
     private List<QnaHeart> qnaHeart = new ArrayList<>();
 
@@ -78,7 +80,7 @@ public class User extends BaseTimeEntity {
     @Builder
     public User(String username, String password, String email, String firstName, String lastName, Gender gender,
                 Country country,String bio,
-                @Nullable OAuthCategory oAuthCategory) {
+                @Nullable OAuthCategory oAuthCategory, @Nullable String oauthUid) {
         this.gender = gender;
         this.country = country;
         this.firstName = firstName;
@@ -87,6 +89,7 @@ public class User extends BaseTimeEntity {
         this.username = username;
         this.password = password;
         this.bio = bio;
+        this.oauthUid = oauthUid;
         this.oauthCategory = oAuthCategory;
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/exception/DuplicateEmailException.java
+++ b/src/main/java/com/example/kbuddy_backend/user/exception/DuplicateEmailException.java
@@ -1,8 +1,8 @@
 package com.example.kbuddy_backend.user.exception;
 
-import com.example.kbuddy_backend.common.exception.BadRequestException;
+import com.example.kbuddy_backend.common.exception.DuplicateException;
 
-public class DuplicateEmailException extends BadRequestException {
+public class DuplicateEmailException extends DuplicateException {
     public DuplicateEmailException() {
         super("이미 존재하는 이메일입니다.");
     }

--- a/src/main/java/com/example/kbuddy_backend/user/exception/DuplicateUserException.java
+++ b/src/main/java/com/example/kbuddy_backend/user/exception/DuplicateUserException.java
@@ -1,8 +1,8 @@
 package com.example.kbuddy_backend.user.exception;
 
-import com.example.kbuddy_backend.common.exception.BadRequestException;
+import com.example.kbuddy_backend.common.exception.DuplicateException;
 
-public class DuplicateUserException extends BadRequestException {
+public class DuplicateUserException extends DuplicateException {
     public DuplicateUserException() {
         super("이미 존재하는 사용자입니다.");
     }

--- a/src/main/java/com/example/kbuddy_backend/user/exception/DuplicateUserIdException.java
+++ b/src/main/java/com/example/kbuddy_backend/user/exception/DuplicateUserIdException.java
@@ -1,0 +1,8 @@
+package com.example.kbuddy_backend.user.exception;
+import com.example.kbuddy_backend.common.exception.DuplicateException;
+
+public class DuplicateUserIdException extends DuplicateException {
+    public DuplicateUserIdException() {
+        super("이미 존재하는 사용자 아이디입니다.");
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.example.kbuddy_backend.user.repository;
 
 import com.example.kbuddy_backend.user.constant.OAuthCategory;
 import com.example.kbuddy_backend.user.entity.User;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +14,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauthUidAndOauthCategory(String oauthUid, OAuthCategory oauthCategory);
 
     boolean existsByEmail(String email);
+
+    boolean existsByUsername(String username);
 }

--- a/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
@@ -9,7 +9,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByEmailAndOauthCategory(String email, OAuthCategory oAuthCategory);
+    Optional<User> findByOauthUidAndOauthCategory(String oauthUid, OAuthCategory oAuthCategory);
 
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
@@ -16,4 +16,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     boolean existsByEmail(String email);
 
     boolean existsByUsername(String username);
+
+    Optional<User> findByUsernameOrEmail(String emailOrUserId, String emailOrUserId1);
 }

--- a/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
@@ -9,7 +9,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsername(String username);
     Optional<User> findByEmail(String email);
 
-    Optional<User> findByOauthUidAndOauthCategory(String oauthUid, OAuthCategory oAuthCategory);
+    Optional<User> findByOauthUidAndOauthCategory(String oauthUid, OAuthCategory oauthCategory);
 
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
@@ -2,8 +2,6 @@ package com.example.kbuddy_backend.user.repository;
 
 import com.example.kbuddy_backend.user.constant.OAuthCategory;
 import com.example.kbuddy_backend.user.entity.User;
-import jakarta.validation.constraints.Email;
-import jakarta.validation.constraints.NotNull;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -13,9 +11,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthUidAndOauthCategory(String oauthUid, OAuthCategory oauthCategory);
 
-    boolean existsByEmail(String email);
+    boolean existsByEmailAndOauthCategoryIsNullAndOauthUidIsNull(String email);
 
     boolean existsByUsername(String username);
 
-    Optional<User> findByUsernameOrEmail(String emailOrUserId, String emailOrUserId1);
+    Optional<User> findByUsernameOrEmailAndOauthCategoryIsNullAndOauthUidIsNull(String emailOrUserId, String emailOrUserId1);
 }

--- a/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
+++ b/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
@@ -118,37 +118,24 @@ public class UserAuthService {
 
     public AccessTokenAndRefreshTokenResponse login(final LoginRequest loginRequest) {
 
-        final String email = loginRequest.email();
+        final String emailOrUserId = loginRequest.emailOrUserId();
         final String password = loginRequest.password();
 
-        final Optional<User> user = userRepository.findByEmail(email);
-
-        if (user.isEmpty()) {
-            throw new UserNotFoundException();
-        }
-
-        final User findUser = user.get();
-
-        if (!passwordEncoder.matches(password, findUser.getPassword())) {
+        //사용자 아이디 or 이메일을 통해 로그인
+        User user = userRepository.findByUsernameOrEmail(emailOrUserId, emailOrUserId).orElseThrow(UserNotFoundException::new);
+        if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new InvalidPasswordException();
         }
         UsernamePasswordAuthenticationToken authenticationToken = getUsernamePasswordAuthenticationToken(
-                findUser, password);
+                user, password);
 
         return authService.createToken(authenticationToken);
     }
 
     public AccessTokenAndRefreshTokenResponse oAuthLogin(final OAuthLoginRequest loginRequest) {
-        final Optional<User> user = userRepository.findByOauthUidAndOauthCategory(loginRequest.oAuthUid(), loginRequest.oAuthCategory());
-
-        if (user.isEmpty()) {
-            throw new UserNotFoundException();
-        }
-
-        final User findUser = user.get();
-
+        final User user = userRepository.findByOauthUidAndOauthCategory(loginRequest.oAuthUid(), loginRequest.oAuthCategory()).orElseThrow(UserNotFoundException::new);
         UsernamePasswordAuthenticationToken authenticationToken = getUsernamePasswordAuthenticationToken(
-                findUser, "oAuth");
+                user, "oAuth");
 
         return authService.createToken(authenticationToken);
     }

--- a/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
+++ b/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
@@ -82,18 +82,14 @@ public class UserAuthService {
 
     @Transactional
     public AccessTokenAndRefreshTokenResponse oAuthRegister(final OAuthRegisterRequest registerRequest) {
-
-        final String email = registerRequest.email();
-        final String username = registerRequest.userId();
-
-        Optional<User> user = userRepository.findByOauthUidAndOauthCategory(registerRequest.oauthUid(),
+        Optional<User> user = userRepository.findByOauthUidAndOauthCategory(registerRequest.oAuthUid(),
                 registerRequest.oAuthCategory());
 
         if (user.isPresent()) {
             throw new DuplicateUserException();
         }
 
-        final User newUser = createOAuthUser(registerRequest, username, email);
+        final User newUser = createOAuthUser(registerRequest);
 
         newUser.addAuthority(new Authority(NORMAL_USER));
         User saveUser = userRepository.save(newUser);
@@ -104,20 +100,20 @@ public class UserAuthService {
         return authService.createToken(authenticationToken);
     }
 
-    private User createOAuthUser(OAuthRegisterRequest registerRequest, String username, String email) {
+    private User createOAuthUser(OAuthRegisterRequest registerRequest) {
         return User.builder()
-                .username(username)
+                .username(registerRequest.userId())
                 .oAuthCategory(registerRequest.oAuthCategory())
-                .oauthUid(registerRequest.userId())
+                .oAuthUid(registerRequest.oAuthUid())
                 .firstName(registerRequest.firstName())
                 .lastName(registerRequest.lastName())
                 .country(registerRequest.country())
                 .gender(registerRequest.gender())
-                .email(email).build();
+                .email(registerRequest.email()).build();
     }
 
     public boolean checkOAuthUser(final OAuthLoginRequest request) {
-        return userRepository.findByOauthUidAndOauthCategory(request.oauthUid(), request.oauth()).isPresent();
+        return userRepository.findByOauthUidAndOauthCategory(request.oAuthUid(), request.oAuthCategory()).isPresent();
     }
 
     public AccessTokenAndRefreshTokenResponse login(final LoginRequest loginRequest) {
@@ -143,10 +139,7 @@ public class UserAuthService {
     }
 
     public AccessTokenAndRefreshTokenResponse oAuthLogin(final OAuthLoginRequest loginRequest) {
-
-        final String oauthUid = loginRequest.oauthUid();
-
-        final Optional<User> user = userRepository.findByOauthUidAndOauthCategory(oauthUid, loginRequest.oauth());
+        final Optional<User> user = userRepository.findByOauthUidAndOauthCategory(loginRequest.oAuthUid(), loginRequest.oAuthCategory());
 
         if (user.isEmpty()) {
             throw new UserNotFoundException();

--- a/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
+++ b/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
@@ -41,8 +41,6 @@ public class UserAuthService {
         //todo: final default 설정하기
         //todo: 유효성 검사 및 테스트 코드
         final String email = registerRequest.email();
-        final String username = registerRequest.userId();
-
         Optional<User> user = userRepository.findByEmail(email);
 
         if (user.isPresent()) {
@@ -50,7 +48,7 @@ public class UserAuthService {
         }
 
         final String password = passwordEncoder.encode(registerRequest.password());
-        final User newUser = createUser(registerRequest, username, email, password);
+        final User newUser = createUser(registerRequest, password);
 
         newUser.addAuthority(new Authority(NORMAL_USER));
         User saveUser = userRepository.save(newUser);
@@ -69,14 +67,15 @@ public class UserAuthService {
         return new UsernamePasswordAuthenticationToken(saveUser.getId(), password, grantedAuthorities);
     }
 
-    private static User createUser(RegisterRequest registerRequest, String username, String email, String password) {
+    private static User createUser(RegisterRequest registerRequest,String password) {
         return User.builder()
-                .username(username)
+                .username(registerRequest.userId())
                 .firstName(registerRequest.firstName())
                 .lastName(registerRequest.lastName())
                 .country(registerRequest.country())
                 .gender(registerRequest.gender())
-                .email(email)
+                .birthDate(registerRequest.birthDate())
+                .email(registerRequest.email())
                 .password(password).build();
     }
 
@@ -109,6 +108,7 @@ public class UserAuthService {
                 .lastName(registerRequest.lastName())
                 .country(registerRequest.country())
                 .gender(registerRequest.gender())
+                .birthDate(registerRequest.birthDate())
                 .email(registerRequest.email()).build();
     }
 

--- a/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
+++ b/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
@@ -41,11 +41,9 @@ public class UserAuthService {
         //todo: final default 설정하기
         //todo: 유효성 검사 및 테스트 코드
         final String email = registerRequest.email();
-        Optional<User> user = userRepository.findByEmail(email);
-
-        if (user.isPresent()) {
+        userRepository.findByEmail(email).ifPresent(user -> {
             throw new DuplicateUserException();
-        }
+        });
 
         final String password = passwordEncoder.encode(registerRequest.password());
         final User newUser = createUser(registerRequest, password);
@@ -81,12 +79,10 @@ public class UserAuthService {
 
     @Transactional
     public AccessTokenAndRefreshTokenResponse oAuthRegister(final OAuthRegisterRequest registerRequest) {
-        Optional<User> user = userRepository.findByOauthUidAndOauthCategory(registerRequest.oAuthUid(),
-                registerRequest.oAuthCategory());
-
-        if (user.isPresent()) {
+        userRepository.findByOauthUidAndOauthCategory(registerRequest.oAuthUid(),
+                registerRequest.oAuthCategory()).ifPresent(user -> {
             throw new DuplicateUserException();
-        }
+        });
 
         final User newUser = createOAuthUser(registerRequest);
 

--- a/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
+++ b/src/main/java/com/example/kbuddy_backend/user/service/UserAuthService.java
@@ -15,8 +15,8 @@ import com.example.kbuddy_backend.user.exception.DuplicateUserException;
 import com.example.kbuddy_backend.user.exception.InvalidPasswordException;
 import com.example.kbuddy_backend.user.exception.UserNotFoundException;
 import com.example.kbuddy_backend.user.repository.UserRepository;
+import com.example.kbuddy_backend.user.util.UserConverter;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
@@ -40,13 +40,13 @@ public class UserAuthService {
 
         //todo: final default 설정하기
         //todo: 유효성 검사 및 테스트 코드
-        final String email = registerRequest.email();
-        userRepository.findByEmail(email).ifPresent(user -> {
+        userRepository.findByUsernameOrEmailAndOauthCategoryIsNullAndOauthUidIsNull(registerRequest.userId(),
+                registerRequest.email()).ifPresent(user -> {
             throw new DuplicateUserException();
         });
 
         final String password = passwordEncoder.encode(registerRequest.password());
-        final User newUser = createUser(registerRequest, password);
+        final User newUser = UserConverter.fromRegisterRequest(registerRequest, password);
 
         newUser.addAuthority(new Authority(NORMAL_USER));
         User saveUser = userRepository.save(newUser);
@@ -57,26 +57,6 @@ public class UserAuthService {
         return authService.createToken(authenticationToken);
     }
 
-    private static UsernamePasswordAuthenticationToken getUsernamePasswordAuthenticationToken(User saveUser,
-                                                                                              String password) {
-        List<GrantedAuthority> grantedAuthorities = saveUser.getAuthorities().stream()
-                .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName().name()))
-                .collect(Collectors.toList());
-        return new UsernamePasswordAuthenticationToken(saveUser.getId(), password, grantedAuthorities);
-    }
-
-    private static User createUser(RegisterRequest registerRequest,String password) {
-        return User.builder()
-                .username(registerRequest.userId())
-                .firstName(registerRequest.firstName())
-                .lastName(registerRequest.lastName())
-                .country(registerRequest.country())
-                .gender(registerRequest.gender())
-                .birthDate(registerRequest.birthDate())
-                .email(registerRequest.email())
-                .password(password).build();
-    }
-
     @Transactional
     public AccessTokenAndRefreshTokenResponse oAuthRegister(final OAuthRegisterRequest registerRequest) {
         userRepository.findByOauthUidAndOauthCategory(registerRequest.oAuthUid(),
@@ -84,7 +64,7 @@ public class UserAuthService {
             throw new DuplicateUserException();
         });
 
-        final User newUser = createOAuthUser(registerRequest);
+        final User newUser = UserConverter.fromOAuthRegisterRequest(registerRequest);
 
         newUser.addAuthority(new Authority(NORMAL_USER));
         User saveUser = userRepository.save(newUser);
@@ -93,19 +73,6 @@ public class UserAuthService {
                 saveUser, "oAuth");
 
         return authService.createToken(authenticationToken);
-    }
-
-    private User createOAuthUser(OAuthRegisterRequest registerRequest) {
-        return User.builder()
-                .username(registerRequest.userId())
-                .oAuthCategory(registerRequest.oAuthCategory())
-                .oAuthUid(registerRequest.oAuthUid())
-                .firstName(registerRequest.firstName())
-                .lastName(registerRequest.lastName())
-                .country(registerRequest.country())
-                .gender(registerRequest.gender())
-                .birthDate(registerRequest.birthDate())
-                .email(registerRequest.email()).build();
     }
 
     public boolean checkOAuthUser(final OAuthLoginRequest request) {
@@ -118,10 +85,12 @@ public class UserAuthService {
         final String password = loginRequest.password();
 
         //사용자 아이디 or 이메일을 통해 로그인
-        User user = userRepository.findByUsernameOrEmail(emailOrUserId, emailOrUserId).orElseThrow(UserNotFoundException::new);
+        User user = userRepository.findByUsernameOrEmailAndOauthCategoryIsNullAndOauthUidIsNull(emailOrUserId, emailOrUserId).orElseThrow(UserNotFoundException::new);
+
         if (!passwordEncoder.matches(password, user.getPassword())) {
             throw new InvalidPasswordException();
         }
+
         UsernamePasswordAuthenticationToken authenticationToken = getUsernamePasswordAuthenticationToken(
                 user, password);
 
@@ -139,5 +108,13 @@ public class UserAuthService {
     @Transactional
     public void resetPassword(PasswordRequest passwordRequest, User user) {
         user.resetPassword(passwordEncoder.encode(passwordRequest.password()));
+    }
+
+    private UsernamePasswordAuthenticationToken getUsernamePasswordAuthenticationToken(User saveUser,
+                                                                                              String password) {
+        List<GrantedAuthority> grantedAuthorities = saveUser.getAuthorities().stream()
+                .map(authority -> new SimpleGrantedAuthority(authority.getAuthorityName().name()))
+                .collect(Collectors.toList());
+        return new UsernamePasswordAuthenticationToken(saveUser.getId(), password, grantedAuthorities);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/util/UserConverter.java
+++ b/src/main/java/com/example/kbuddy_backend/user/util/UserConverter.java
@@ -1,0 +1,35 @@
+package com.example.kbuddy_backend.user.util;
+
+import com.example.kbuddy_backend.user.dto.request.OAuthRegisterRequest;
+import com.example.kbuddy_backend.user.dto.request.RegisterRequest;
+import com.example.kbuddy_backend.user.entity.User;
+
+public class UserConverter {
+
+    public static User fromRegisterRequest(RegisterRequest request, String password) {
+        return User.builder()
+                .username(request.userId())
+                .firstName(request.firstName())
+                .lastName(request.lastName())
+                .country(request.country())
+                .gender(request.gender())
+                .birthDate(request.birthDate())
+                .email(request.email())
+                .password(password)
+                .build();
+    }
+
+    public static User fromOAuthRegisterRequest(OAuthRegisterRequest request) {
+        return User.builder()
+                .username(request.userId())
+                .oAuthCategory(request.oAuthCategory())
+                .oAuthUid(request.oAuthUid())
+                .firstName(request.firstName())
+                .lastName(request.lastName())
+                .country(request.country())
+                .gender(request.gender())
+                .birthDate(request.birthDate())
+                .email(request.email())
+                .build();
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -23,7 +23,7 @@ spring:
   jpa:
     show-sql: true
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
     properties:
       hibernate:
         format_sql: true

--- a/src/test/java/com/example/kbuddy_backend/qna/controller/QnaControllerTest.java
+++ b/src/test/java/com/example/kbuddy_backend/qna/controller/QnaControllerTest.java
@@ -28,7 +28,7 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.security.test.context.support.WithMockUser;
 
-@WithMockUser
+@WithMockUser(username = "123", roles = "USER")
 public class QnaControllerTest extends WebMVCTest {
 
     @MockBean
@@ -43,8 +43,8 @@ public class QnaControllerTest extends WebMVCTest {
         QnaResponse qnaResponse = QnaFixtures.createQnaResponse();
         User user = UserFixtures.createUser();
 
-        given(qnaService.saveQna(any(QnaSaveRequest.class), eq(user))).willReturn(qnaResponse);
-        given(userRepository.findByEmail(any())).willReturn(Optional.of(user));
+        given(qnaService.saveQna(any(QnaSaveRequest.class),eq(user))).willReturn(qnaResponse);
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
 
         //when
         mockMvc.perform(post("/kbuddy/v1/qna")

--- a/src/test/java/com/example/kbuddy_backend/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/com/example/kbuddy_backend/user/controller/UserAuthControllerTest.java
@@ -20,8 +20,8 @@ class UserAuthControllerTest extends WebMVCTest {
     @Test
     void loginSuccess() throws Exception {
         //given
-        RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test","test","test", Country.KOREA,
-                Gender.M);
+        RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test","test","test", Country.KR,
+                Gender.M, "000724");
 
         //when
         

--- a/src/test/java/com/example/kbuddy_backend/user/controller/UserAuthControllerTest.java
+++ b/src/test/java/com/example/kbuddy_backend/user/controller/UserAuthControllerTest.java
@@ -9,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.example.kbuddy_backend.common.WebMVCTest;
 import com.example.kbuddy_backend.user.constant.Country;
 import com.example.kbuddy_backend.user.constant.Gender;
+import com.example.kbuddy_backend.user.dto.request.LoginRequest;
 import com.example.kbuddy_backend.user.dto.request.RegisterRequest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,13 +21,12 @@ class UserAuthControllerTest extends WebMVCTest {
     @Test
     void loginSuccess() throws Exception {
         //given
-        RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test","test","test", Country.KR,
-                Gender.M, "000724");
+        LoginRequest loginRequest = LoginRequest.of("test", "test");
 
         //when
         
         //then
-        mockMvc.perform(post("/kbuddy/v1/auth/login").content(objectMapper.writeValueAsString(registerRequest))
+        mockMvc.perform(post("/kbuddy/v1/auth/login").content(objectMapper.writeValueAsString(loginRequest))
                 .contentType(APPLICATION_JSON)).andDo(print())
                 .andExpect(status().isOk());
      }

--- a/src/test/java/com/example/kbuddy_backend/user/service/UserAuthServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/user/service/UserAuthServiceTest.java
@@ -46,8 +46,8 @@ class UserAuthServiceTest extends IntegrationTest {
     @Test
     void loginSuccess() {
         //given
-        RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test", "test", "test", Country.KOREA,
-            Gender.M);
+        RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test", "test", "test", Country.KR,
+            Gender.M,"000724");
         given(userRepository.save(any(User.class))).willReturn(UserFixtures.createUser());
 
         //when
@@ -91,8 +91,8 @@ class UserAuthServiceTest extends IntegrationTest {
     void checkDuplicatedEmail() {
         //given
         User user = UserFixtures.createUser();
-        RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test", "test", "test", Country.KOREA,
-            Gender.M);
+        RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test", "test", "test", Country.KR,
+            Gender.M,"000724");
         given(userRepository.findByEmail(anyString())).willReturn(Optional.of(user));
 
         //then

--- a/src/test/java/com/example/kbuddy_backend/user/service/UserAuthServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/user/service/UserAuthServiceTest.java
@@ -106,7 +106,7 @@ class UserAuthServiceTest extends IntegrationTest {
     void checkOAuthRegisterUser() {
         //given
         OAuthLoginRequest oAuthLoginRequest = OAuthLoginRequest.of("k-buddy@gmail.com", OAuthCategory.KAKAO);
-        given(userRepository.findByEmailAndOauthCategory(anyString(), any())).willReturn(
+        given(userRepository.findByOauthUidAndOauthCategory(anyString(), any())).willReturn(
             Optional.of(UserFixtures.createOAuthUser()));
 
         //then

--- a/src/test/java/com/example/kbuddy_backend/user/service/UserAuthServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/user/service/UserAuthServiceTest.java
@@ -65,7 +65,7 @@ class UserAuthServiceTest extends IntegrationTest {
         User user = UserFixtures.createUser();
         LoginRequest loginRequest = LoginRequest.of("test", "test");
         given(mockRegisterRequest.password()).willReturn("invalidPassword");
-        given(userRepository.findByEmail(anyString())).willReturn(Optional.of(user));
+        given(userRepository.findByUsernameOrEmailAndOauthCategoryIsNullAndOauthUidIsNull(anyString(),anyString())).willReturn(Optional.of(user));
 
         //then
         assertThatThrownBy(() -> userAuthService.login(loginRequest))
@@ -93,7 +93,7 @@ class UserAuthServiceTest extends IntegrationTest {
         User user = UserFixtures.createUser();
         RegisterRequest registerRequest = RegisterRequest.of("test", "test", "test", "test", "test", Country.KR,
             Gender.M,"000724");
-        given(userRepository.findByEmail(anyString())).willReturn(Optional.of(user));
+        given(userRepository.findByUsernameOrEmailAndOauthCategoryIsNullAndOauthUidIsNull(anyString(),anyString())).willReturn(Optional.of(user));
 
         //then
         assertThatThrownBy(() -> userAuthService.register(registerRequest))
@@ -118,7 +118,7 @@ class UserAuthServiceTest extends IntegrationTest {
     void checkChangePassword() {
         //given
         User user = UserFixtures.createUser();
-        given(userRepository.findByEmail(anyString())).willReturn(Optional.of(user));
+        given(userRepository.findByUsernameOrEmailAndOauthCategoryIsNullAndOauthUidIsNull(anyString(),anyString())).willReturn(Optional.of(user));
 
         //when
         userAuthService.resetPassword(PasswordRequest.of("changePassword"), user);


### PR DESCRIPTION
## Description (요약)
1. UserAuthService 리팩토링
2. 사용자 아이디 중복 체크 API 추가
3. 아이디/패스워드, OAuth 인증 로직 변경
4. 테스트 코드 수정

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)
- 사용자 아이디 중복 체크 API를 추가했습니다.
- Json Response에 details 필드를 추가해 자세한 에러 메세지를 담을 수 있게 변경했습니다.(스크린샷)
- 사용자 식별 방식을 수정했습니다. -> OAuth 회원가입 사용자와 아이디/패스워드 회원가입 사용자를 따로 구분하는 것으로 변경했습니다.
- @CurrentUser 어노테이션에서 userId(User 엔티티의 pk)로 사용자를 조회하도록 수정했습니다.
- 사용자 생년월일을 입력받도록 추가했습니다.
- 사용자 아이디 or 이메일로 로그인할 수 있도록 수정했습니다.
- 더 유연한 코드를 위해 리팩토링을 진행했습니다. (UserConverter 클래스 추가, ifPresent 사용 등)

## Screenshots (optional)
![에러발생](https://github.com/user-attachments/assets/ff81b11d-2f08-4642-b274-a564d11a0d11)

## Etc (비고)
- 인증 로직이 적절하게 수행되고 있는지 검토바랍니다.
- 확장성 있는 리팩토링 수행 관점에서 리뷰바랍니다.