### PR TITLE
[FEAT] 블로그 게시글 전체 조회 시에 요구한 size 보다 데이터 갯수가 적으면 nextId: -1 반환기능 추가

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/blog/constant/SortBy.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/constant/SortBy.java
@@ -5,11 +5,5 @@ public enum SortBy {
     HEART_COUNT,   // 좋아요 수 순
     COMMENT_COUNT, // 댓글 수 순
     LATEST,        // 최신순
-    OLDEST,         // 오래된 순
-
-    CATEGORY_VIEW_COUNT,
-    CATEGORY_HEART_COUNT,
-    CATEGORY_COMMENT_COUNT,
-    CATEGORY_LATEST,
-    CATEGORY_OLDEST
+    OLDEST         // 오래된 순
 } 

--- a/src/main/java/com/example/kbuddy_backend/blog/controller/BlogController.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/controller/BlogController.java
@@ -5,6 +5,7 @@ import com.example.kbuddy_backend.blog.dto.request.BlogReportRequest;
 import com.example.kbuddy_backend.blog.dto.request.BlogSaveRequest;
 import com.example.kbuddy_backend.blog.dto.request.BlogUpdateRequest;
 import com.example.kbuddy_backend.blog.dto.response.AllBlogResponse;
+import com.example.kbuddy_backend.blog.dto.response.BlogPaginationResponse;
 import com.example.kbuddy_backend.blog.dto.response.BlogResponse;
 import com.example.kbuddy_backend.blog.service.BlogCommentService;
 import com.example.kbuddy_backend.blog.service.BlogService;
@@ -166,4 +167,14 @@ public class BlogController {
         blogService.reportBlog(blogId, request, user);
         return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
+
+    // 임시 저장 게시글 조회 API
+    @GetMapping("/drafts")
+    @Operation(summary = "내 임시 저장 블로그 목록 조회", description = "현재 로그인한 사용자가 임시 저장한 blog 게시글 전체 목록을 조회합니다.")
+    public ResponseEntity<List<BlogPaginationResponse>> getMyDrafts(
+            @Parameter(hidden = true) @CurrentUser User user) {
+        List<BlogPaginationResponse> drafts = blogService.getMyDrafts(user);
+        return ResponseEntity.ok(drafts);
+    }
+
 } 

--- a/src/main/java/com/example/kbuddy_backend/blog/controller/BlogController.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/controller/BlogController.java
@@ -168,13 +168,4 @@ public class BlogController {
         return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
 
-    // 임시 저장 게시글 조회 API
-    @GetMapping("/drafts")
-    @Operation(summary = "내 임시 저장 블로그 목록 조회", description = "현재 로그인한 사용자가 임시 저장한 blog 게시글 전체 목록을 조회합니다.")
-    public ResponseEntity<List<BlogPaginationResponse>> getMyDrafts(
-            @Parameter(hidden = true) @CurrentUser User user) {
-        List<BlogPaginationResponse> drafts = blogService.getMyDrafts(user);
-        return ResponseEntity.ok(drafts);
-    }
-
 } 

--- a/src/main/java/com/example/kbuddy_backend/blog/entity/Blog.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/entity/Blog.java
@@ -118,6 +118,12 @@ public class Blog extends BaseTimeEntity {
         return comments.size();
     }
 
+    public void setStatus(BlogStatus status) {
+        if (status != null) {
+            this.status = status;
+        }
+    }
+
     public void plusReportCount() {
         this.reportCount += 1;
     }

--- a/src/main/java/com/example/kbuddy_backend/blog/repository/BlogRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/repository/BlogRepository.java
@@ -11,5 +11,6 @@ import java.util.List;
 
 public interface BlogRepository extends JpaRepository<Blog, Long>, BlogRepositoryCustom {
 
+    // 작성자의 모든 블로그와 그 상태(임시저장 여부)를 조회합니다.(no pagination)
     List<Blog> findByWriterAndStatus(User user, BlogStatus blogStatus);
 }

--- a/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
@@ -26,6 +26,7 @@ import com.example.kbuddy_backend.user.entity.User;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.stereotype.Service;
@@ -345,5 +346,31 @@ public class BlogService {
 
     public Blog findBlogById(Long blogId) {
         return blogRepository.findById(blogId).orElseThrow(BlogNotFoundException::new);
+    }
+
+    public List<BlogPaginationResponse> getMyDrafts(User currentUser) {
+
+        List<Blog> draftsBlogs = blogRepository.findByWriterAndStatus(currentUser, BlogStatus.DRAFT);
+        return draftsBlogs.stream()
+                .map(blog -> {
+                    boolean isBookmarked = blogBookmarkRepository.existsByBlogIdAndUserId(blog.getId(), currentUser.getId());
+                    boolean isHearted = blogHeartRepository.existsByBlogIdAndUserId(blog.getId(), currentUser.getId());
+                    return BlogPaginationResponse.of(
+                            blog.getId(),
+                            blog.getWriter().getId(),
+                            blog.getCategoryCode(),
+                            blog.getTitle(),
+                            blog.getDescription(),
+                            blog.getViewCount(),
+                            blog.getHeartCount(),
+                            blog.getCommentCount(),
+                            blog.getCreatedDate(),
+                            blog.getLastModifiedDate(),
+                            blog.getStatus(),
+                            isBookmarked,
+                            isHearted
+                    );
+                })
+                .collect(Collectors.toList()); // 반환값을 리스트로 변환
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
@@ -134,16 +134,19 @@ public class BlogService {
                 })
                 .toList();
 
-        Long nextId = getNextId(blogPaginationResponseList);
+        Long nextId = getNextId(blogPaginationResponseList, pageSize);
 
         return AllBlogResponse.of(nextId, blogPaginationResponseList);
     }
 
-    private Long getNextId(List<BlogPaginationResponse> responses) {
+    private Long getNextId(List<BlogPaginationResponse> responses, int pageSize) {
+        if (responses.isEmpty() || responses.size() < pageSize) {
+            return -1L;
+        }
         return responses.stream()
                 .map(BlogPaginationResponse::id)
                 .reduce((first, second) -> second) // 마지막 ID를 반환
-                .orElse(-1L); // 리스트가 비어있으면 -1 반환
+                .orElse(-1L); //리스트가 비어있으면 -1 반환
     }
 
     // 특정 블로그를 조회하고 조회수를 증가

--- a/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
@@ -347,30 +347,4 @@ public class BlogService {
     public Blog findBlogById(Long blogId) {
         return blogRepository.findById(blogId).orElseThrow(BlogNotFoundException::new);
     }
-
-    public List<BlogPaginationResponse> getMyDrafts(User currentUser) {
-
-        List<Blog> draftsBlogs = blogRepository.findByWriterAndStatus(currentUser, BlogStatus.DRAFT);
-        return draftsBlogs.stream()
-                .map(blog -> {
-                    boolean isBookmarked = blogBookmarkRepository.existsByBlogIdAndUserId(blog.getId(), currentUser.getId());
-                    boolean isHearted = blogHeartRepository.existsByBlogIdAndUserId(blog.getId(), currentUser.getId());
-                    return BlogPaginationResponse.of(
-                            blog.getId(),
-                            blog.getWriter().getId(),
-                            blog.getCategoryCode(),
-                            blog.getTitle(),
-                            blog.getDescription(),
-                            blog.getViewCount(),
-                            blog.getHeartCount(),
-                            blog.getCommentCount(),
-                            blog.getCreatedDate(),
-                            blog.getLastModifiedDate(),
-                            blog.getStatus(),
-                            isBookmarked,
-                            isHearted
-                    );
-                })
-                .collect(Collectors.toList()); // 반환값을 리스트로 변환
-    }
 }


### PR DESCRIPTION
## Description (요약)
불러오는 size 보다 데이터 수가 적으면 nextId를 -1로 반환하는 기능을 추가했습니다.
기존 기능: 무한스크롤 맨 마지막까지 갔을때 nextId를 -1로 반환
## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)


## Screenshots (optional)


## Etc (비고)