### PR TITLE
[FEAT] 유저정보 조회에서 오는 id값을 uuid로 변경 - 유저 uuid 값과 비교해 본인의 글인지 판단하기 위함

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/service/BlogService.java
@@ -181,7 +181,7 @@ public class BlogService {
             if (currentUser == null) {
                 throw new AccessDeniedException("로그인이 필요합니다.");
             }
-            if (!Objects.equals(blogById.getWriter().getId(), currentUser.getId())) {
+            if (!Objects.equals(blogById.getWriter().getUuid(), currentUser.getUuid())) {
                 throw new AccessDeniedException("임시 저장된 글은 작성자만 조회할 수 있습니다."); // Or use NotWriterException
             }
         }
@@ -232,7 +232,7 @@ public class BlogService {
     }
 
     private static void isBlogWriter(User user, Blog blogById) {
-        if (!Objects.equals(blogById.getWriter().getId(), user.getId())) {
+        if (!Objects.equals(blogById.getWriter().getUuid(), user.getUuid())) {
             throw new NotWriterException();
         }
     }

--- a/src/main/java/com/example/kbuddy_backend/qna/service/QnaService.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/service/QnaService.java
@@ -176,7 +176,7 @@ public class QnaService {
             if (currentUser == null) {
                 throw new AccessDeniedException("로그인이 필요합니다.");
             }
-            if (!Objects.equals(qnaById.getWriter().getId(), currentUser.getId())) {
+            if (!Objects.equals(qnaById.getWriter().getUuid(), currentUser.getUuid())) {
                 throw new AccessDeniedException("임시 저장된 글은 작성자만 조회할 수 있습니다."); // Or use NotWriterException
             }
         }
@@ -218,7 +218,7 @@ public class QnaService {
     }
 
     private static void isQnaWriter(User user, Qna qnaById) {
-        if (!Objects.equals(qnaById.getWriter().getId(), user.getId())) {
+        if (!Objects.equals(qnaById.getWriter().getUuid(), user.getUuid())) {
             throw new NotWriterException();
         }
     }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/response/DraftListResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/response/DraftListResponse.java
@@ -5,13 +5,13 @@ import com.example.kbuddy_backend.qna.constant.QnaStatus;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record DraftListResponse(Long id, Long writerId, String type, Object categoryId, String title, String description, List<ImageFileDto> images,
+public record DraftListResponse(Long id, String writerUuid, String type, Object categoryId, String title, String description, List<ImageFileDto> images,
                        LocalDateTime createdAt, LocalDateTime modifiedAt,
                                 String status) {
-    public static DraftListResponse of(Long id, Long writerId,String type, Object categoryId, String title, String description, List<ImageFileDto> images,
+    public static DraftListResponse of(Long id, String writerUuid,String type, Object categoryId, String title, String description, List<ImageFileDto> images,
                                                                                       LocalDateTime createdAt, LocalDateTime modifiedAt,
                                                                                        String status) {
-        return new DraftListResponse(id, writerId,type, categoryId, title, description, images, createdAt, modifiedAt, status);
+        return new DraftListResponse(id, writerUuid, type, categoryId, title, description, images, createdAt, modifiedAt, status);
     }
 
 }

--- a/src/main/java/com/example/kbuddy_backend/user/dto/response/UserResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/response/UserResponse.java
@@ -7,14 +7,14 @@ import com.example.kbuddy_backend.user.entity.User;
 import java.time.LocalDateTime;
 import java.util.List;
 
-public record UserResponse(Long id, String userId, String email, List<String> roles,String profileImageUrl, String bio, String firstName,
+public record UserResponse(String uuid, String userId, String email, List<String> roles,String profileImageUrl, String bio, String firstName,
                            String lastName,
                            Gender gender, Country country, boolean isActive,LocalDateTime createdDate) {
 
-    public static UserResponse of(Long id, String userId, String email, List<String> roles, String profileImageUrl, String bio,
+    public static UserResponse of(String uuid, String userId, String email, List<String> roles, String profileImageUrl, String bio,
                                   String firstName, String lastName, LocalDateTime createdDate, Gender gender,
                                   Country country,boolean isActive) {
-        return new UserResponse(id, userId, email,roles, profileImageUrl, bio, firstName, lastName, gender, country,isActive,
+        return new UserResponse(uuid, userId, email,roles, profileImageUrl, bio, firstName, lastName, gender, country,isActive,
                 createdDate);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/user/service/UserService.java
+++ b/src/main/java/com/example/kbuddy_backend/user/service/UserService.java
@@ -45,7 +45,7 @@ public class UserService {
         List<String> authorities = findUser.getAuthorities().stream()
                 .map(authority -> authority.getAuthorityName().name())
                 .toList();
-        return UserResponse.of(findUser.getId(), findUser.getUsername(), findUser.getEmail(), authorities,
+        return UserResponse.of(findUser.getUuid().toString(), findUser.getUsername(), findUser.getEmail(), authorities,
                 findUser.getProfileImageUrl(), findUser.getBio(), findUser.getFirstName(), findUser.getLastName(),
                 findUser.getCreatedDate(), findUser.getGender(), findUser.getCountry(), findUser.isActive());
     }
@@ -78,7 +78,7 @@ public class UserService {
         List<DraftListResponse> qnaDrafts = draftQnas.stream()
                 .map(qna -> DraftListResponse.of(
                         qna.getId(),
-                        qna.getWriter().getId(),
+                        qna.getWriter().getUuid().toString(),
                         QnaType,
                         qna.getCategoryCode(),
                         qna.getTitle(),
@@ -102,7 +102,7 @@ public class UserService {
         List<DraftListResponse> blogDrafts = draftBlogs.stream()
                 .map(blog -> DraftListResponse.of(
                         blog.getId(),
-                        blog.getWriter().getId(),
+                        blog.getWriter().getUuid().toString(),
                         BlogType,
                         blog.getCategoryCode(),
                         blog.getTitle(),


### PR DESCRIPTION
## Description (요약)
클라이언트와 주고받는 데이터에서 실제 DB ID 대신 UUID를 사용하도록 변경하여 보안을 강화했습니다. 이를 통해 사용자 식별 정보가 노출되는 것을 방지하고 UUID를 통해 본인의 글인지 판단할 수 있도록 개선했습니다.

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
API Testing Tool: Swagger UI

## Major Changes (주요 변경사항)
1. UserResponse DTO 수정
   - `id` 필드를 `uuid`로 변경
   - 응답 시 UUID 문자열 반환하도록 수정

2. UserService 수정
   - `getUser` 메서드에서 UUID 반환하도록 수정
   - 작성자 확인 로직에서 UUID 사용하도록 변경

3. 관련 서비스 로직 수정
   - 작성자 확인 로직을 UUID 기반으로 변경
   - 임시 저장글 조회 권한 확인 로직 수정

## Screenshots (optional)


## Etc (비고)