### PR TITLE
[FEAT]유저가 자기가 쓴 글 확인할 수 있는 API 구현

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/user/controller/UserPageController.java
+++ b/src/main/java/com/example/kbuddy_backend/user/controller/UserPageController.java
@@ -3,11 +3,7 @@ package com.example.kbuddy_backend.user.controller;
 import com.example.kbuddy_backend.common.config.CurrentUser;
 import com.example.kbuddy_backend.qna.dto.response.QnaPaginationResponse;
 import com.example.kbuddy_backend.user.dto.request.UserBioRequest;
-import com.example.kbuddy_backend.user.dto.response.BookmarkedPostResponse;
-import com.example.kbuddy_backend.user.dto.response.DefaultResponse;
-import com.example.kbuddy_backend.user.dto.response.DraftListResponse;
-import com.example.kbuddy_backend.user.dto.response.UserProfileResponse;
-import com.example.kbuddy_backend.user.dto.response.UserResponse;
+import com.example.kbuddy_backend.user.dto.response.*;
 import com.example.kbuddy_backend.user.entity.User;
 import com.example.kbuddy_backend.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
@@ -56,6 +52,14 @@ public class UserPageController {
             @Parameter(hidden = true) @CurrentUser User user) {
         List<BookmarkedPostResponse> bookmarks = userService.getMyBookmarks(user);
         return ResponseEntity.ok(bookmarks);
+    }
+
+    @GetMapping("/myArticles")
+    @Operation(summary = "내가 작성한 게시글 목록 조회", description = "현재 로그인한 사용자가 작성한 블로그와 Q&A 게시글 전체 목록을 조회합니다.")
+    public ResponseEntity<List<MyArticleResponse>> getMyArticle(
+            @Parameter(hidden = true) @CurrentUser User user) {
+        List<MyArticleResponse> articles = userService.getMyArticle(user);
+        return ResponseEntity.ok(articles);
     }
 
     @PatchMapping(value = "/profile", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)

--- a/src/main/java/com/example/kbuddy_backend/user/dto/response/MyArticleResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/user/dto/response/MyArticleResponse.java
@@ -1,0 +1,47 @@
+package com.example.kbuddy_backend.user.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record MyArticleResponse(
+        Long id,
+        String writerUuid,
+        String writerName,
+        String writerProfileImageUrl,
+        String postType, // "BLOG" 또는 "QNA"
+        List<Integer> categoryId,
+        String title,
+        String description,
+        int viewCount,
+        int heartCount,
+        int commentCount,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        String thumbnailImageUrl,
+        boolean isHearted,
+        boolean isBookmarked
+) {
+    public static MyArticleResponse of(
+            Long id,
+            String writerUuid,
+            String writerName,
+            String writerProfileImageUrl,
+            String postType,
+            List<Integer> categoryId,
+            String title,
+            String description,
+            int viewCount,
+            int heartCount,
+            int commentCount,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt,
+            String thumbnailImageUrl,
+            boolean isHearted,
+            boolean isBookmarked
+    ) {
+        return new MyArticleResponse(
+                id, writerUuid, writerName, writerProfileImageUrl, postType, categoryId, title, description,
+                viewCount, heartCount, commentCount, createdAt, modifiedAt, thumbnailImageUrl, isHearted, isBookmarked
+        );
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/user/service/UserService.java
+++ b/src/main/java/com/example/kbuddy_backend/user/service/UserService.java
@@ -13,10 +13,7 @@ import com.example.kbuddy_backend.qna.entity.QnaBookmark;
 import com.example.kbuddy_backend.qna.repository.QnaBookmarkRepository;
 import com.example.kbuddy_backend.qna.repository.QnaHeartRepository;
 import com.example.kbuddy_backend.qna.repository.QnaRepository;
-import com.example.kbuddy_backend.user.dto.response.BookmarkedPostResponse;
-import com.example.kbuddy_backend.user.dto.response.DraftListResponse;
-import com.example.kbuddy_backend.user.dto.response.UserProfileResponse;
-import com.example.kbuddy_backend.user.dto.response.UserResponse;
+import com.example.kbuddy_backend.user.dto.response.*;
 import com.example.kbuddy_backend.user.entity.User;
 import com.example.kbuddy_backend.user.repository.UserRepository;
 import com.example.kbuddy_backend.s3.service.S3Service;
@@ -204,5 +201,69 @@ public class UserService {
         allBookmarks.sort(Comparator.comparing(BookmarkedPostResponse::createdAt).reversed());
         
         return allBookmarks;
+    }
+
+    public List<MyArticleResponse> getMyArticle(User user) {
+        // QNA 본인 게시글 조회
+        List<Qna> myQnas = qnaRepository.findByWriterAndStatus(user, QnaStatus.PUBLISHED);
+        List<MyArticleResponse> qnaArticles = myQnas.stream()
+                .map(qna -> {
+                    String thumbnailImageUrl = qna.getImageUrls() != null && !qna.getImageUrls().isEmpty()
+                            ? qna.getImageUrls().get(0).getImageUrl()
+                            : "";
+                    return MyArticleResponse.of(
+                            qna.getId(),
+                            qna.getWriter().getUuid().toString(),
+                            qna.getWriter().getUsername(),
+                            qna.getWriter().getProfileImageUrl() != null ? qna.getWriter().getProfileImageUrl() : "",
+                            "QNA",
+                            List.of(qna.getCategoryCode()),
+                            qna.getTitle(),
+                            qna.getDescription(),
+                            qna.getViewCount(),
+                            qna.getHeartCount(),
+                            qna.getCommentCount(),
+                            qna.getCreatedDate(),
+                            qna.getLastModifiedDate(),
+                            thumbnailImageUrl,
+                            qnaHeartRepository.existsByQnaIdAndUserId(qna.getId(), user.getId()),
+                            false // 내가 쓴 글이므로 북마크는 false
+                    );
+                })
+                .toList();
+
+        // 블로그 본인 게시글 조회
+        List<Blog> myBlogs = blogRepository.findByWriterAndStatus(user, BlogStatus.PUBLISHED);
+        List<MyArticleResponse> blogArticles = myBlogs.stream()
+                .map(blog -> {
+                    String thumbnailImageUrl = blog.getImageUrls() != null && !blog.getImageUrls().isEmpty()
+                            ? blog.getImageUrls().get(0).getImageUrl()
+                            : "";
+                    return MyArticleResponse.of(
+                            blog.getId(),
+                            blog.getWriter().getUuid().toString(),
+                            blog.getWriter().getUsername(),
+                            blog.getWriter().getProfileImageUrl() != null ? blog.getWriter().getProfileImageUrl() : "",
+                            "BLOG",
+                            blog.getCategoryCode(),
+                            blog.getTitle(),
+                            blog.getDescription(),
+                            blog.getViewCount(),
+                            blog.getHeartCount(),
+                            blog.getCommentCount(),
+                            blog.getCreatedDate(),
+                            blog.getLastModifiedDate(),
+                            thumbnailImageUrl,
+                            blogHeartRepository.existsByBlogIdAndUserId(blog.getId(), user.getId()),
+                            false // 내가 쓴 글이므로 북마크는 false
+                    );
+                })
+                .toList();
+
+        List<MyArticleResponse> allArticles = new ArrayList<>();
+        allArticles.addAll(qnaArticles);
+        allArticles.addAll(blogArticles);
+        allArticles.sort(Comparator.comparing(MyArticleResponse::createdAt).reversed());
+        return allArticles;
     }
 }


### PR DESCRIPTION
## Description (요약)
현재 로그인한 사용자가 작성한 블로그와 Q&A 게시글 전체 목록을 조회합니다.

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
Local/Dev 환경에서 Postman 및 Swagger로 테스트

## Major Changes (주요 변경사항)
- UserPageController에 /kbuddy/v1/user/myArticles GET API 추가
- UserService에 getMyArticle(User user) 메서드 추가
- 본인이 작성한 블로그/큐앤에이 게시글을 통합하여 반환하는 DTO(MyArticleResponse) 추가
- BlogRepository, QnaRepository에서 작성자+상태로 게시글 조회하는 메서드 활용

## Screenshots (optional)


## Etc (비고)