### PR TITLE
[FEAT] QnA 신고 기능 추가

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/qna/controller/QnaController.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/controller/QnaController.java
@@ -5,6 +5,7 @@ import com.example.kbuddy_backend.common.advice.response.ErrorResponse;
 import com.example.kbuddy_backend.common.config.CurrentUser;
 import com.example.kbuddy_backend.qna.constant.SortBy;
 import com.example.kbuddy_backend.qna.dto.request.QnaCommentSaveRequest;
+import com.example.kbuddy_backend.qna.dto.request.QnaReportRequest;
 import com.example.kbuddy_backend.qna.dto.request.QnaSaveRequest;
 import com.example.kbuddy_backend.qna.dto.request.QnaUpdateRequest;
 import com.example.kbuddy_backend.qna.dto.response.AllQnaResponse;
@@ -122,5 +123,13 @@ public class QnaController {
     public ResponseEntity<Void> minusQnaHeart(@PathVariable Long qnaId, @Parameter(hidden = true) @CurrentUser User user) {
         qnaService.minusHeart(qnaId, user);
         return ResponseEntity.noContent().build(); // 204 No content 반환
+    }
+
+    //Qna 신고
+    @PostMapping("/{qnaId}/report")
+    @Operation(summary = "Q&A 게시글 신고", description = "Qna 게시글을 신고합니다.")
+    public ResponseEntity<String> reportQna(@PathVariable Long qnaId, @RequestBody QnaReportRequest request, @Parameter(hidden = true) @CurrentUser User user) {
+        qnaService.reportQna(qnaId, request, user);
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/qna/dto/request/QnaReportRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/dto/request/QnaReportRequest.java
@@ -1,0 +1,7 @@
+package com.example.kbuddy_backend.qna.dto.request;
+
+import com.example.kbuddy_backend.blog.dto.request.BlogReportRequest;
+
+public record QnaReportRequest(String content) {
+    public QnaReportRequest of(String content) { return  new QnaReportRequest(content); }
+}

--- a/src/main/java/com/example/kbuddy_backend/qna/entity/Qna.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/entity/Qna.java
@@ -62,6 +62,7 @@ public class Qna extends BaseTimeEntity {
 
     private int heartCount;
     private int viewCount;
+    private int reportCount;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
@@ -136,5 +137,9 @@ public class Qna extends BaseTimeEntity {
         if (status != null) {
             this.status = status;
         }
+    }
+
+    public void plusReportCount() {
+        this.reportCount += 1;
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/qna/entity/QnaReport.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/entity/QnaReport.java
@@ -1,0 +1,46 @@
+package com.example.kbuddy_backend.qna.entity;
+
+import com.example.kbuddy_backend.common.entity.BaseTimeEntity;
+import com.example.kbuddy_backend.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "qna_report")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QnaReport extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "qnareport_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User reporter;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "qna_id")
+    private Qna qna;
+
+    private String content;
+
+    @Builder
+    public QnaReport(User reporter, Qna qna, String content) {
+        this.reporter = reporter;
+        this.qna = qna;
+        this.content = content;
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/qna/entity/QnaReport.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/entity/QnaReport.java
@@ -24,7 +24,7 @@ public class QnaReport extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "qnareport_id")
+    @Column(name = "qna_report_id")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/example/kbuddy_backend/qna/repository/QnaReportRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/repository/QnaReportRepository.java
@@ -1,0 +1,11 @@
+package com.example.kbuddy_backend.qna.repository;
+
+import com.example.kbuddy_backend.qna.entity.QnaReport;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QnaReportRepository extends JpaRepository<QnaReport, Long> {
+    boolean existsByQnaIdAndReporterId(Long qnaId, Long reportId);
+    List<QnaReport> findAllByQnaId(Long qnaId);
+}

--- a/src/main/java/com/example/kbuddy_backend/qna/service/QnaService.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/service/QnaService.java
@@ -4,6 +4,7 @@ import com.example.kbuddy_backend.common.constant.ImageFileType;
 import com.example.kbuddy_backend.common.dto.ImageFileDto;
 import com.example.kbuddy_backend.qna.constant.SortBy;
 import com.example.kbuddy_backend.qna.constant.QnaStatus;
+import com.example.kbuddy_backend.qna.dto.request.QnaReportRequest;
 import com.example.kbuddy_backend.qna.dto.request.QnaSaveRequest;
 import com.example.kbuddy_backend.qna.dto.request.QnaUpdateRequest;
 import com.example.kbuddy_backend.qna.dto.response.AllQnaResponse;
@@ -15,16 +16,18 @@ import com.example.kbuddy_backend.qna.entity.QnaBookmark;
 import com.example.kbuddy_backend.qna.entity.QnaHeart;
 import com.example.kbuddy_backend.qna.entity.QnaImage;
 import com.example.kbuddy_backend.qna.entity.QnaComment;
+import com.example.kbuddy_backend.qna.entity.QnaReport;
 import com.example.kbuddy_backend.qna.exception.*;
 import com.example.kbuddy_backend.qna.repository.*;
 import com.example.kbuddy_backend.s3.dto.response.S3Response;
 import com.example.kbuddy_backend.s3.service.S3Service;
 import com.example.kbuddy_backend.user.entity.User;
-import com.example.kbuddy_backend.user.exception.UserNotFoundException;
+import com.example.kbuddy_backend.user.exception.UserNotFoundException;;
 import com.example.kbuddy_backend.user.service.UserBlockService;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import com.example.kbuddy_backend.common.exception.DuplicateException;
 
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -52,6 +55,7 @@ public class QnaService {
     private final QnaHeartRepository qnaHeartRepository;
     private final QnaBookmarkRepository qnaBookmarkRepository;
     private final QnaImageRepository qnaImageRepository;
+    private final QnaReportRepository qnaReportRepository;
     private final S3Service s3Service;
     private final QnaCommentRepository qnaCommentRepository;
     private final UserBlockService userBlockService;
@@ -401,6 +405,32 @@ public class QnaService {
         QnaBookmark qnaBookmark = qnaBookmarkRepository.findByQnaIdAndUserId(qnaId, user.getId())
                 .orElseThrow(QnaBookmarkNotFoundException::new);
         qnaBookmarkRepository.delete(qnaBookmark);
+    }
+
+    @Transactional
+    public void reportQna(Long qnaId, QnaReportRequest request, User user) {
+        // 신고하려는 Qna가 존재하는지 확인
+        Qna qna = qnaRepository.findById(qnaId)
+                .orElseThrow(QnaNotFoundException::new);
+
+        // 이미 신고한 Qna인지 확인
+        if (qnaReportRepository.existsByQnaIdAndReporterId(qnaId, user.getId())) {
+            throw new DuplicateException("이미 신고한 Q&A 입니다.");
+        }
+
+        // 자신이 쓴 블로그 신고하는지 확인
+        if (qna.getWriter().getId().equals(user.getId())) {
+            throw new BadRequestException(("자신의 Q&A 글을 신고할 수 없습니다."));
+        }
+
+        QnaReport report = QnaReport.builder()
+                .qna(qna)
+                .reporter(user)
+                .content(request.content())
+                .build();
+
+        qnaReportRepository.save(report);
+        qna.plusReportCount();
     }
 
     public Qna findQnaById(Long qnaId) {


### PR DESCRIPTION
## Description (요약)
Qna에 신고 기능 추가

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
Swagger (Bearer JWT 인증)

## Major Changes (주요 변경사항)
QnA 신고 엔드포인트 추가
- POST /kbuddy/v1/qna/{qnaId}/report (QnaController)
신고 요청 DTO 추가
- qna/dto/request/QnaReportRequest
신고 엔티티/레포지토리 추가
- qna/entity/QnaReport
- qna/repository/QnaReportRepository (existsByQnaIdAndReporterId, findAllByQnaId)
서비스 로직 추가
- QnaService.reportQna(qnaId, request, user)
- 유효성 검사: 존재 여부 확인, 중복 신고 방지, 자기 글 신고 금지
- 저장 후 Qna.plusReportCount()로 신고 카운트 증가
기타 정리
- QnaController, QnaReportRequest 불필요 import 제거
- QnaService에 필요한 import 보완 (QnaReport, DuplicateException 등)

## Screenshots (optional)


## Etc (비고)
Swagger 테스트 절차
- POST /kbuddy/v1/auth/login으로 액세스 토큰 발급 → Swagger 우상단 Authorize에 설정
- POST /kbuddy/v1/qna/{qnaId}/report
``` { "content": "스팸/부적절한 내용입니다." } ```
- 기대 응답: 204 No Content

에러 스펙
- 중복 신고: 409 Conflict
- 자기 글 신고: 400 Bad Request
- 존재하지 않는 QnA: 422 Unprocessable Entity
- 인증 누락/만료: 401 Unauthorized

호환성: 신규 엔드포인트 추가로 기존 API에는 영향 없음

DB: qna_report 테이블 필요