### PR TITLE
[FEAT] iOS/Android별 FCM 메시지 타입 분리 (Android data-only)

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/notification/controller/FCMTokenController.java
+++ b/src/main/java/com/example/kbuddy_backend/notification/controller/FCMTokenController.java
@@ -1,6 +1,7 @@
 package com.example.kbuddy_backend.notification.controller;
 
 import com.example.kbuddy_backend.common.config.CurrentUser;
+import com.example.kbuddy_backend.notification.entity.DevicePlatform;
 import com.example.kbuddy_backend.notification.entity.FCMToken;
 import com.example.kbuddy_backend.notification.service.FCMTokenService;
 import com.example.kbuddy_backend.user.entity.User;
@@ -24,8 +25,9 @@ public class FCMTokenController {
     public ResponseEntity<FCMToken> registerToken(
             @CurrentUser User user,
             @RequestParam String token,
-            @RequestParam(required = false) String deviceInfo) {
-        fcmTokenService.registerToken(user, token, deviceInfo);
+            @RequestParam(required = false) String deviceInfo,
+            @RequestParam DevicePlatform platform) {
+        fcmTokenService.registerToken(user, token, deviceInfo, platform);
         return ResponseEntity.noContent().build();
     }
 

--- a/src/main/java/com/example/kbuddy_backend/notification/entity/DevicePlatform.java
+++ b/src/main/java/com/example/kbuddy_backend/notification/entity/DevicePlatform.java
@@ -1,0 +1,6 @@
+package com.example.kbuddy_backend.notification.entity;
+
+public enum DevicePlatform {
+    IOS,
+    ANDROID
+}

--- a/src/main/java/com/example/kbuddy_backend/notification/entity/FCMToken.java
+++ b/src/main/java/com/example/kbuddy_backend/notification/entity/FCMToken.java
@@ -34,6 +34,10 @@ public class FCMToken {
     @Column
     private String deviceInfo;
 
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 16)
+    private DevicePlatform platform;
+
     @Column(nullable = false)
     private Boolean isActive = true;
 

--- a/src/main/java/com/example/kbuddy_backend/notification/service/FCMService.java
+++ b/src/main/java/com/example/kbuddy_backend/notification/service/FCMService.java
@@ -1,5 +1,6 @@
 package com.example.kbuddy_backend.notification.service;
 
+import com.example.kbuddy_backend.notification.entity.DevicePlatform;
 import com.example.kbuddy_backend.notification.entity.FCMToken;
 import com.example.kbuddy_backend.user.entity.User;
 import com.google.firebase.messaging.FirebaseMessaging;
@@ -29,23 +30,20 @@ public class FCMService {
      */
     public void sendNotification(String token, String title, String body, String type, String targetId) {
         try {
-            // 알림 메시지 생성
-            Message message = Message.builder()
+            // 토큰으로 플랫폼 조회 (없으면 기본 iOS처럼 동작)
+            DevicePlatform platform = fcmTokenService.findByToken(token)
+                    .map(FCMToken::getPlatform)
+                    .orElse(DevicePlatform.IOS);
+
+            Message.Builder builder = Message.builder()
                     .setToken(token)
-                    // Foreground용 Notification 메시지
-                    .setNotification(
-                            Notification.builder()
-                                    .setTitle(title)
-                                    .setBody(body)
-                                    .build()
-                    )
-                    // Background용 Data 메시지
+                    // 공통 data
                     .putData("title", title)
                     .putData("body", body)
                     .putData("click_action", type)
-                    .putData("deep_link", targetId) // 딥링크 예시
+                    .putData("deep_link", targetId)
                     .putData("time", String.valueOf(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)))
-                    // iOS 설정
+                    // iOS 설정은 있어도 notification 미포함 시 data-only로 동작 가능
                     .setApnsConfig(ApnsConfig.builder()
                             .putHeader("apns-priority", "10")
                             .setAps(Aps.builder()
@@ -53,14 +51,22 @@ public class FCMService {
                                     .setSound("default")
                                     .build())
                             .build())
-                    // Android 설정
                     .setAndroidConfig(AndroidConfig.builder()
                             .setPriority(AndroidConfig.Priority.HIGH)
-                            .build())
-                    .build();
+                            .build());
 
-            // FCM을 통해 메시지 전송
-            FirebaseMessaging.getInstance().send(message);
+            // 플랫폼별 notification 포함 여부 분기
+            if (platform == DevicePlatform.IOS) {
+                builder.setNotification(
+                        Notification.builder()
+                                .setTitle(title)
+                                .setBody(body)
+                                .build()
+                );
+            }
+            // ANDROID는 notification 미설정 → data-only
+
+            FirebaseMessaging.getInstance().send(builder.build());
         } catch (Exception e) {
             throw new RuntimeException("Failed to send FCM notification", e);
         }

--- a/src/main/java/com/example/kbuddy_backend/notification/service/FCMTokenService.java
+++ b/src/main/java/com/example/kbuddy_backend/notification/service/FCMTokenService.java
@@ -1,5 +1,6 @@
 package com.example.kbuddy_backend.notification.service;
 
+import com.example.kbuddy_backend.notification.entity.DevicePlatform;
 import com.example.kbuddy_backend.notification.entity.FCMToken;
 import com.example.kbuddy_backend.notification.repository.FCMTokenRepository;
 import com.example.kbuddy_backend.user.entity.User;
@@ -17,7 +18,7 @@ public class FCMTokenService {
     private final FCMTokenRepository fcmTokenRepository;
 
     @Transactional
-    public void registerToken(User user, String token, String deviceInfo) {
+    public void registerToken(User user, String token, String deviceInfo, DevicePlatform platform) {
         Optional<FCMToken> existing = fcmTokenRepository.findByToken(token);
         if (existing.isPresent()) {
             FCMToken fcmToken = existing.get();
@@ -25,14 +26,21 @@ public class FCMTokenService {
             fcmToken.setUser(user);
             fcmToken.setUpdatedAt(LocalDateTime.now());
             fcmToken.setDeviceInfo(deviceInfo);
+            fcmToken.setPlatform(platform);
             return;
         }
         FCMToken newToken = new FCMToken();
         newToken.setUser(user);
         newToken.setToken(token);
         newToken.setDeviceInfo(deviceInfo);
+        newToken.setPlatform(platform);
         newToken.setIsActive(true);
         fcmTokenRepository.save(newToken);
+    }
+
+    @Transactional(readOnly = true)
+    public Optional<FCMToken> findByToken(String token) {
+        return fcmTokenRepository.findByToken(token);
     }
 
     @Transactional


### PR DESCRIPTION
## Description (요약)
iOS/Android 플랫폼에 따라 FCM 알림 페이로드를 분리했습니다.
- Android: notification 미포함(data-only)
- iOS: notification + data 포함
FCM 토큰 등록 시 플랫폼 정보(IOS/ANDROID)를 함께 저장하도록 확장했습니다.

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)
FCM 발송 로직 분기
- FCMService: 토큰의 플랫폼 조회 후 iOS는 message.notification 포함, Android는 data-only로 전송
토큰 모델/등록 확장
- FCMToken에 platform 필드 추가
- FCMTokenController/FCMTokenService: 토큰 등록 시 platform 파라미터 필수 처리
API 계약 변경
- 토큰 등록 API: platform(IOS/ANDROID) 필수 파라미터 추가

## Screenshots (optional)


## Etc (비고)