### PR TITLE
[FEAT] Android 알림 처리 방식 변경: deviceInfo 값이 Android일때는 notification 미포함(data-only)

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/notification/controller/FCMController.java
+++ b/src/main/java/com/example/kbuddy_backend/notification/controller/FCMController.java
@@ -33,9 +33,11 @@ public class FCMController {
             @Parameter(description = "추가 데이터 타입", required = false)
             @RequestParam String dataType,
             @Parameter(description = "추가 데이터 ID", required = false)
-            @RequestParam String dataId
+            @RequestParam String dataId,
+            @Parameter(description = "디바이스 정보(android/ios 등)", required = true)
+            @RequestParam String deviceInfo
     ) {
-        fcmService.sendNotification(token, title, body,dataType,dataId);
+        fcmService.sendNotification(token, title, body,dataType,dataId, deviceInfo);
         return "알림이 성공적으로 전송되었습니다.";
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/notification/service/FCMService.java
+++ b/src/main/java/com/example/kbuddy_backend/notification/service/FCMService.java
@@ -26,38 +26,45 @@ public class FCMService {
      * @param token 클라이언트의 FCM 토큰
      * @param title 알림 제목
      * @param body 알림 내용
+     * @param deviceInfo 디바이스 타입(android/ios) 등
      */
-    public void sendNotification(String token, String title, String body, String type, String targetId) {
+    public void sendNotification(String token, String title, String body, String type, String targetId, String deviceInfo) {
         try {
-            // 알림 메시지 생성
-            Message message = Message.builder()
+            Message.Builder builder = Message.builder()
                     .setToken(token)
-                    // Foreground용 Notification 메시지
-                    .setNotification(
-                            Notification.builder()
-                                    .setTitle(title)
-                                    .setBody(body)
-                                    .build()
-                    )
-                    // Background용 Data 메시지
                     .putData("title", title)
                     .putData("body", body)
                     .putData("click_action", type)
-                    .putData("deep_link", targetId) // 딥링크 예시
-                    .putData("time", String.valueOf(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)))
-                    // iOS 설정
-                    .setApnsConfig(ApnsConfig.builder()
-                            .putHeader("apns-priority", "10")
-                            .setAps(Aps.builder()
-                                    .setContentAvailable(true)
-                                    .setSound("default")
-                                    .build())
-                            .build())
-                    // Android 설정
-                    .setAndroidConfig(AndroidConfig.builder()
-                            .setPriority(AndroidConfig.Priority.HIGH)
-                            .build())
-                    .build();
+                    .putData("deep_link", targetId)
+                    .putData("time", String.valueOf(LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)));
+
+            // iOS의 경우 Notification 포함, Android의 경우 미포함
+            if (!"android".equalsIgnoreCase(deviceInfo)) {
+                builder.setNotification(Notification.builder()
+                        .setTitle(title)
+                        .setBody(body)
+                        .build());
+            }
+
+            // iOS 설정
+            if ("ios".equalsIgnoreCase(deviceInfo)) {
+                builder.setApnsConfig(ApnsConfig.builder()
+                        .putHeader("apns-priority", "10")
+                        .setAps(Aps.builder()
+                                .setContentAvailable(true)
+                                .setSound("default")
+                                .build())
+                        .build());
+            }
+
+            // Android 설정
+            if ("android".equalsIgnoreCase(deviceInfo)) {
+                builder.setAndroidConfig(AndroidConfig.builder()
+                        .setPriority(AndroidConfig.Priority.HIGH)
+                        .build());
+            }
+
+            Message message = builder.build();
 
             // FCM을 통해 메시지 전송
             FirebaseMessaging.getInstance().send(message);
@@ -75,11 +82,11 @@ public class FCMService {
     public void sendNotificationAllFcmTokens(User user, String title, String message, String type, String targetId) {
         // 사용자의 모든 활성 FCM 토큰 조회
         List<FCMToken> activeTokens = fcmTokenService.getActiveTokens(user);
-        
+
         // 각 토큰에 대해 알림 전송
         for (FCMToken token : activeTokens) {
             try {
-                sendNotification(token.getToken(), title, message, type, targetId);
+                sendNotification(token.getToken(), title, message, type, targetId, token.getDeviceInfo());
             } catch (Exception e) {
                 // 토큰이 유효하지 않은 경우 비활성화
                 fcmTokenService.deactivateToken(token.getToken());


### PR DESCRIPTION
## Description (요약)
플랫폼 정보 처리(FCM 알림 분기)를 단순화합니다.
- deviceInfo(문자열) 기반으로 플랫폼(android/ios) 정보를 관리하도록 되돌립니다.
- FCM 발송 시, deviceInfo 값이 "android"일 때는 notification 미포함(data-only), 그 외(iOS)에는 notification + data를 포함합니다.
- DevicePlatform enum 및 관련 필드/파라미터를 제거하고 기존 deviceInfo(String) 중심으로 다시 설계하였습니다.

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [x] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)

## Major Changes (주요 변경사항)
[플랫폼 분기 및 모델 구조 단순화]
FCMService:
- sendNotification()에서 DevicePlatform enum 대신, deviceInfo 문자열("android"/"ios")로 분기 처리
- deviceInfo가 "android"면 Notification 포함하지 않고 data-only 전송
- 그 외(iOS 등)는 Notification + data 모두 전송
FCMToken:
- DevicePlatform enum, 관련 필드, @Enumerated, @Column(length=16) 등 제거
- deviceInfo(String) 필드를 통해만 플랫폼 정보 저장 및 사용
FCMTokenController/FCMTokenService:
- 토큰 등록 시 platform(enum) 파라미터 제거
- 오직 deviceInfo(문자열: "android" or "ios")만 받아 저장

## Why: 변경 이유
별도의 enum 도입 없이 이미 토큰에 저장된 deviceInfo 문자열 필드를 활용
플랫폼 추가 확장 시 코드 수정 부담을 줄이고 프론트-서버 통신 구조를 간단하게 유지
기존 enum 기반 구조와 동일한 분기(안드로이드는 notification 미포함, iOS는 포함) 실현

## 참고
기존 PR(DevicePlatform enum 기반)
해당 PR은 deviceInfo 기반 구조로 rollback/리팩토링되고, enum/관련 필드를 모두 제거함