### PR TITLE
[FEAT] 공지사항 게시판 구현

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/announcement/constant/SortBy.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/constant/SortBy.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.constant;
+
+public enum SortBy {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/constant/SortBy.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/constant/SortBy.java
@@ -1,4 +1,5 @@
 package com.example.kbuddy_backend.announcement.constant;
 
 public enum SortBy {
+    LASTEST
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/controller/AnnouncementController.java
@@ -1,4 +1,82 @@
 package com.example.kbuddy_backend.announcement.controller;
 
+import com.example.kbuddy_backend.announcement.constant.SortBy;
+import com.example.kbuddy_backend.announcement.dto.request.AnnouncementSaveRequest;
+import com.example.kbuddy_backend.announcement.dto.request.AnnouncementUpdateRequest;
+import com.example.kbuddy_backend.announcement.dto.response.AllAnnouncementResponse;
+import com.example.kbuddy_backend.announcement.dto.response.AnnouncementResponse;
+import com.example.kbuddy_backend.announcement.service.AnnouncementService;
+import com.example.kbuddy_backend.common.config.CurrentUser;
+import com.example.kbuddy_backend.user.dto.response.DefaultResponse;
+import com.example.kbuddy_backend.user.entity.User;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.parameters.P;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("kbuddy/v1/announcement")
+@Tag(name = "Announcement API", description = "공지사항 API 목록")
 public class AnnouncementController {
+
+    private final AnnouncementService announcementService;
+
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "공지사항 게시글 작성", description = "공지사항 게시글을 작성합니다. qnaSaveRequest는 JSON 형식의 문자열로, 이미지는 선택적으로 multipart form data로 전송합니다.")
+    public ResponseEntity<DefaultResponse> saveAnnouncement(
+            @Valid @RequestPart(value = "announcementSaveRequest") AnnouncementSaveRequest announcementSaveRequest,
+            @RequestPart(value = "images", required = false) List<MultipartFile> images,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        announcementService.saveAnnouncement(announcementSaveRequest, images, user);
+        return ResponseEntity.noContent().build(); // 204 No Content 반환
+    }
+
+    //전체 조회(페이징)
+    @GetMapping
+    @Operation(summary = "공지사항 게시글 전체 조회", description = "공지사항 게시글을 최신순으로 전체 조회 합니다.")
+    public ResponseEntity<AllAnnouncementResponse> getAllAnouncement(@RequestParam(value = "size") int pageSize,
+                                                                     @RequestParam(value = "id", required = false) Long announcementId,
+                                                                     @RequestParam(value = "keyword", defaultValue = "") String title,
+                                                                     @RequestParam(required = false, value = "sort") SortBy sortBy,
+                                                                     @Parameter(hidden = true) @CurrentUser User user) {
+        AllAnnouncementResponse allAnnouncementResponse = announcementService.getAllAnnouncement(pageSize, announcementId, title, sortBy, user);
+        return ResponseEntity.ok().body(allAnnouncementResponse);
+    }
+
+    @GetMapping("/{announcementId}")
+    @Operation(summary = "특정 공지사항 게시글 조회", description = "공지사항 게시글 id를 통해 조회합니다.")
+    public ResponseEntity<AnnouncementResponse> getAnnouncement(
+            @PathVariable Long announcementId,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        AnnouncementResponse announcement = announcementService.getAnnouncement(announcementId, user);
+        return ResponseEntity.ok().body(announcement);
+    }
+
+    @PatchMapping(value = "/{announcementId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary = "공지사항 게시글 업데이트", description = "공지사항 게시글을 업데이트 합니다. 이미지 추가/삭제 등을 포함합니다.")
+    public ResponseEntity<AnnouncementResponse> updateAnouncement(
+            @PathVariable final Long announcementId,
+            @Valid @RequestPart(value = "announcementUpadate") AnnouncementUpdateRequest announcementUpdateRequest,
+            @RequestPart(value = "images", required = false) List<MultipartFile> newFiles,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        AnnouncementResponse announcement = announcementService.updateAnnouncement(announcementId, announcementUpdateRequest, newFiles, user);
+        return ResponseEntity.ok().body(announcement);
+    }
+
+    @DeleteMapping("/{announcementId}")
+    @Operation(summary = "공지사항 게시글 삭제", description = "공지사항 게시글을 삭제합니다.")
+    public ResponseEntity<Void> deleteAnnouncement(@PathVariable final Long announcementId, @Parameter(hidden = true) @CurrentUser User user) {
+        announcementService.deleteAnnouncement(announcementId, user);
+        return ResponseEntity.noContent().build();
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/controller/AnnouncementController.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/controller/AnnouncementController.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.controller;
+
+public class AnnouncementController {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementImageRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementImageRequest.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.dto.request;
+
+public class AnnouncementImageRequest {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementImageRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementImageRequest.java
@@ -1,4 +1,9 @@
 package com.example.kbuddy_backend.announcement.dto.request;
 
-public class AnnouncementImageRequest {
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record AnnouncementImageRequest(
+        @NotEmpty(message = "이미지 목록은 비어있을 수 없습니다.")
+        List<String> images) {
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementSaveRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementSaveRequest.java
@@ -1,4 +1,23 @@
 package com.example.kbuddy_backend.announcement.dto.request;
 
-public record AnnouncementSaveRequest() {
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+public record AnnouncementSaveRequest(
+        @Schema(description = "공지사항 게시글 제목", example = "공지사항 게시글 제목", maxLength = 100, requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "제목 필드는 필수입니다")
+        @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다")
+        String title,
+
+        @Schema(description = "공지사항 게시글 내용", example = "공지사항 게시글 내용", requiredMode = Schema.RequiredMode.REQUIRED)
+        @NotNull(message = "내용 필드는 필수입니다")
+        String description
+) {
+    public static AnnouncementSaveRequest of(String title, String description) {
+        return new AnnouncementSaveRequest(title, description);
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementSaveRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementSaveRequest.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.dto.request;
+
+public record AnnouncementSaveRequest() {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementUpdateRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementUpdateRequest.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.dto.request;
+
+public record AnnouncementUpdateRequest() {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementUpdateRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/request/AnnouncementUpdateRequest.java
@@ -1,4 +1,28 @@
 package com.example.kbuddy_backend.announcement.dto.request;
 
-public record AnnouncementUpdateRequest() {
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Size;
+
+import java.util.List;
+
+@Schema(description = "공지사항 게시글 업데이트 요청")
+public record AnnouncementUpdateRequest(
+
+        @Schema(description = "공지사항 게시글 제목", example = "25.11월 업데이트 내용", requiredMode = Schema.RequiredMode.NOT_REQUIRED, maxLength = 100)
+        @Size(max = 100, message = "제목은 최대 100자까지 입력 가능합니다")
+        String title,
+
+        @Schema(description = "공지사항 게시글 내용", example = "상담 기능이 업데이트 됐습니다.")
+        String description,
+
+        @Schema(description = "삭제할 기존 이미지 ID 목록", example = "[4, 5]", requiredMode = Schema.RequiredMode.NOT_REQUIRED)
+        List<Long> deleteImageIds
+) {
+    public static AnnouncementUpdateRequest of(
+            String title,
+            String description,
+            List<Long> deleteImageIds
+    ) {
+        return new AnnouncementUpdateRequest(title, description, deleteImageIds);
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AllAnnouncementResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AllAnnouncementResponse.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.dto.response;
+
+public record AllAnnouncementResponse() {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AllAnnouncementResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AllAnnouncementResponse.java
@@ -1,4 +1,9 @@
 package com.example.kbuddy_backend.announcement.dto.response;
 
-public record AllAnnouncementResponse() {
+import java.util.List;
+
+public record AllAnnouncementResponse(Long nextId, List<AnnouncementPaginationResponse> results) {
+    public static AllAnnouncementResponse of(Long nextId, List<AnnouncementPaginationResponse> results) {
+        return new AllAnnouncementResponse(nextId, results);
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementPaginationResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementPaginationResponse.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.dto.response;
+
+public record AnnouncementPaginationResponse() {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementPaginationResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementPaginationResponse.java
@@ -1,4 +1,42 @@
 package com.example.kbuddy_backend.announcement.dto.response;
 
-public record AnnouncementPaginationResponse() {
+import java.time.LocalDateTime;
+
+public record AnnouncementPaginationResponse(
+        Long id,
+        String writerUuid,
+        String writerName,
+        String writerProfileImageUrl,
+        String title,
+        String description,
+        int viewCount,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt,
+        String thumbnailImageUrl
+) {
+    public static AnnouncementPaginationResponse of(
+            Long id,
+            String writerUuid,
+            String writerName,
+            String writerProfileImageUrl,
+            String title,
+            String description,
+            int viewCount,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt,
+            String thumbnailImageUrl
+    ) {
+        return new AnnouncementPaginationResponse(
+                id,
+                writerUuid,
+                writerName,
+                writerProfileImageUrl,
+                title,
+                description,
+                viewCount,
+                createdAt,
+                modifiedAt,
+                thumbnailImageUrl
+        );
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementResponse.java
@@ -1,4 +1,4 @@
-package com.example.kbuddy_backend.announcement.dto.request;
+package com.example.kbuddy_backend.announcement.dto.response;
 
 import com.example.kbuddy_backend.common.dto.ImageFileDto;
 
@@ -12,7 +12,8 @@ public record AnnouncementResponse(
     String writerProfileImageUrl,
     String title,
     String description,
-    LocalDateTime createAt,
+    int viewCount,
+    LocalDateTime createdAt,
     LocalDateTime modifiedAt,
     List<ImageFileDto> images
 ) {
@@ -23,8 +24,9 @@ public record AnnouncementResponse(
             String writerProfileImageUrl,
             String title,
             String description,
+            int viewCount,
             LocalDateTime createdAt,
-            LocalDateTime modifiedAt
+            LocalDateTime modifiedAt,
             List<ImageFileDto>images
 ) {
     return new AnnouncementResponse(
@@ -34,6 +36,7 @@ public record AnnouncementResponse(
             writerProfileImageUrl,
             title,
             description,
+            viewCount,
             createdAt,
             modifiedAt,
             images

--- a/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/dto/response/AnnouncementResponse.java
@@ -1,0 +1,42 @@
+package com.example.kbuddy_backend.announcement.dto.request;
+
+import com.example.kbuddy_backend.common.dto.ImageFileDto;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public record AnnouncementResponse(
+    Long id,
+    String writerUuid,
+    String writerName,
+    String writerProfileImageUrl,
+    String title,
+    String description,
+    LocalDateTime createAt,
+    LocalDateTime modifiedAt,
+    List<ImageFileDto> images
+) {
+    public static AnnouncementResponse of(
+            Long id,
+            String writerUuid,
+            String writerName,
+            String writerProfileImageUrl,
+            String title,
+            String description,
+            LocalDateTime createdAt,
+            LocalDateTime modifiedAt
+            List<ImageFileDto>images
+) {
+    return new AnnouncementResponse(
+            id,
+            writerUuid,
+            writerName,
+            writerProfileImageUrl,
+            title,
+            description,
+            createdAt,
+            modifiedAt,
+            images
+    );
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/entity/Announcement.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/entity/Announcement.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.entity;
+
+public class Announcement {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/entity/Announcement.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/entity/Announcement.java
@@ -1,4 +1,65 @@
 package com.example.kbuddy_backend.announcement.entity;
 
-public class Announcement {
+import com.example.kbuddy_backend.common.entity.BaseTimeEntity;
+import com.example.kbuddy_backend.user.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@Table(name = "announcement")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Announcement extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "announcement_id")
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User writer;
+
+    @OneToMany(mappedBy = "announcement", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AnnouncementImage> imageUrls = new ArrayList<>();
+
+    private String title;
+    private String description;
+
+    private int viewCount;
+
+    @Builder
+    public Announcement(User writer, String title, String description){
+        this.writer = writer;
+        this.title = title;
+        this.description = description;
+    }
+
+    public void update(String title, String description){
+        if(title != null && !title.isEmpty()){
+            this.title = title;
+        }
+        if(description != null && !description.isEmpty()){
+            this.description = description;
+        }
+    }
+
+    public void addImage(AnnouncementImage announcementImage){
+        announcementImage.setAnnouncement(this);
+        imageUrls.add(announcementImage);
+    }
+
+    public void deleteImage(Long imageId) {
+        imageUrls.removeIf(image -> image.getId().equals(imageId));
+    }
+
+    public void plusViewCount() {
+        this.viewCount += 1;
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/entity/AnnouncementImage.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/entity/AnnouncementImage.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.entity;
+
+public class AnnouncementImage {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/entity/AnnouncementImage.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/entity/AnnouncementImage.java
@@ -1,4 +1,42 @@
 package com.example.kbuddy_backend.announcement.entity;
 
+import com.example.kbuddy_backend.blog.entity.Blog;
+import com.example.kbuddy_backend.common.constant.ImageFileType;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AnnouncementImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "announce_id")
+    private Announcement announcement;
+
+    private String imageUrl;
+    @Enumerated(EnumType.STRING)
+    private ImageFileType fileType;
+
+    private String filePath;
+    private final LocalDateTime createdAt = LocalDateTime.now();
+
+    @Builder
+    public AnnouncementImage(Announcement announcement, String imageUrl, ImageFileType fileType, String filePath) {
+        this.announcement = announcement;
+        this.imageUrl = imageUrl;
+        this.fileType = fileType;
+        this.filePath = filePath;
+    }
+
+    public void setAnnouncement(Announcement announcement) {this.announcement = announcement;}
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementImageNotFoundException.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementImageNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.kbuddy_backend.announcement.exception;
+
+public class AnnouncementImageNotFoundException extends RuntimeException {
+  public AnnouncementImageNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementImageNotFoundException.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementImageNotFoundException.java
@@ -1,7 +1,9 @@
 package com.example.kbuddy_backend.announcement.exception;
 
-public class AnnouncementImageNotFoundException extends RuntimeException {
-  public AnnouncementImageNotFoundException(String message) {
-    super(message);
-  }
+import com.example.kbuddy_backend.common.exception.NotFoundException;
+
+public class AnnouncementImageNotFoundException extends NotFoundException {
+    public AnnouncementImageNotFoundException() {
+        super("공지사항을 찾을 수 없습니다.");
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementNotFoundException.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementNotFoundException.java
@@ -1,7 +1,7 @@
 package com.example.kbuddy_backend.announcement.exception;
 
 public class AnnouncementNotFoundException extends RuntimeException {
-  public AnnouncementNotFoundException(String message) {
-    super(message);
-  }
+    public AnnouncementNotFoundException() {
+        super("공지사항 게시글을 찾을 수 없습니다.");
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementNotFoundException.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/exception/AnnouncementNotFoundException.java
@@ -1,0 +1,7 @@
+package com.example.kbuddy_backend.announcement.exception;
+
+public class AnnouncementNotFoundException extends RuntimeException {
+  public AnnouncementNotFoundException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/exception/NotWriterException.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/exception/NotWriterException.java
@@ -1,4 +1,7 @@
 package com.example.kbuddy_backend.announcement.exception;
 
-public class NotWriterException {
+public class NotWriterException extends IllegalArgumentException{
+    public NotWriterException() {
+        super("작성자가 아닙니다.");
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/exception/NotWriterException.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/exception/NotWriterException.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.exception;
+
+public class NotWriterException {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementImageRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementImageRepository.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.repository;
+
+public interface AnnouncementImageRepository {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementImageRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementImageRepository.java
@@ -1,4 +1,8 @@
 package com.example.kbuddy_backend.announcement.repository;
 
-public interface AnnouncementImageRepository {
+import com.example.kbuddy_backend.announcement.entity.AnnouncementImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnouncementImageRepository extends JpaRepository<AnnouncementImage, Long> {
+    void deleteByFilePath(String filePath);
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepository.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.repository;
+
+public interface announcementRepository {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepository.java
@@ -1,4 +1,9 @@
 package com.example.kbuddy_backend.announcement.repository;
 
-public interface announcementRepository {
+import com.example.kbuddy_backend.announcement.entity.Announcement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AnnouncementRepository extends JpaRepository<Announcement, Long>, AnnouncementRepositoryCustom {
+
+    // Find Announcements by writer and status
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryCustom.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryCustom.java
@@ -1,4 +1,11 @@
 package com.example.kbuddy_backend.announcement.repository;
 
+import com.example.kbuddy_backend.announcement.constant.SortBy;
+import com.example.kbuddy_backend.announcement.entity.Announcement;
+
+import java.util.List;
+
 public interface AnnouncementRepositoryCustom {
+
+    List<Announcement> paginationNoOffset(Long announcementId, String title, int pageSize, SortBy sortBy);
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryCustom.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryCustom.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.repository;
+
+public interface AnnouncementRepositoryCustom {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryImpl.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryImpl.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.repository;
+
+public interface AnnouncementRepositoryImpl {
+}

--- a/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryImpl.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/repository/AnnouncementRepositoryImpl.java
@@ -1,4 +1,48 @@
 package com.example.kbuddy_backend.announcement.repository;
 
-public interface AnnouncementRepositoryImpl {
+import static com.example.kbuddy_backend.announcement.entity.QAnnouncement.announcement;
+
+import com.example.kbuddy_backend.announcement.constant.SortBy;
+import com.example.kbuddy_backend.announcement.entity.Announcement;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class AnnouncementRepositoryImpl implements AnnouncementRepositoryCustom{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<Announcement> paginationNoOffset(Long announcementId, String title, int pageSize, SortBy sortBy) {
+        return jpaQueryFactory.selectFrom(announcement)
+                .where(
+                        ltAnnouncementId(announcementId),
+                        titleOrDescriptionContains(title)
+                )
+                .orderBy(getOrderSpecifier(sortBy))
+                .limit(pageSize)
+                .fetch();
+    }
+
+    private BooleanExpression ltAnnouncementId(Long announcementId) {
+        if(announcementId == null) {
+            return null;
+        }
+        return announcement.id.lt(announcementId);
+    }
+
+    private BooleanExpression titleOrDescriptionContains(String keyword) {
+        if(keyword == null || keyword.trim().isEmpty()) {
+            return null;
+        }
+        return announcement.title.like("%" + keyword + "%").or(announcement.description.like("%" + keyword + "%"));
+    }
+
+    private OrderSpecifier<?> getOrderSpecifier(SortBy sortBy) {
+        return announcement.id.desc();
+    }
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/service/AnnouncementService.java
@@ -1,4 +1,268 @@
 package com.example.kbuddy_backend.announcement.service;
 
+import com.example.kbuddy_backend.common.constant.ImageFileType;
+import com.example.kbuddy_backend.common.dto.ImageFileDto;
+import com.example.kbuddy_backend.notification.service.FCMService;
+import com.example.kbuddy_backend.announcement.constant.SortBy;
+import com.example.kbuddy_backend.announcement.dto.request.*;
+import com.example.kbuddy_backend.announcement.dto.response.*;
+import com.example.kbuddy_backend.announcement.entity.Announcement;
+import com.example.kbuddy_backend.announcement.entity.AnnouncementImage;
+import com.example.kbuddy_backend.announcement.exception.*;
+import com.example.kbuddy_backend.announcement.repository.*;
+import com.example.kbuddy_backend.s3.dto.response.S3Response;
+import com.example.kbuddy_backend.s3.service.S3Service;
+import com.example.kbuddy_backend.user.entity.User;
+import com.example.kbuddy_backend.user.exception.UserNotFoundException;;
+import com.example.kbuddy_backend.user.service.UserBlockService;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import com.example.kbuddy_backend.common.exception.DuplicateException;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+import com.example.kbuddy_backend.common.exception.BadRequestException;
+
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
 public class AnnouncementService {
+
+    private static final int MAX_ANNOUNCEMENT_IMAGES = 5;
+
+    private final AnnouncementRepository announcementRepository;
+    private final AnnouncementImageRepository announcementImageRepository;
+    private final S3Service s3Service;
+    private final FCMService fcmService;
+
+
+    @Transactional
+    public AnnouncementResponse saveAnnouncement(AnnouncementSaveRequest announcementSaveRequest, List<MultipartFile> imageFiles, User user) {
+        if(imageFiles != null && imageFiles.size() > MAX_ANNOUNCEMENT_IMAGES) {
+            throw new BadRequestException("공지사항 게시글에는 이미지를 최대 " + MAX_ANNOUNCEMENT_IMAGES + "개까지 첨부할 수 있습니다.");
+        }
+
+        if(Objects.equals(announcementSaveRequest.title(), "")) {
+            throw new BadRequestException("제목을 입력해주세요.");
+        }
+        if(Objects.equals(announcementSaveRequest.description(), "")) {
+            throw new BadRequestException("내용을 입력해주세요.");
+        }
+
+        Announcement announcement = Announcement.builder()
+                .writer(user)
+                .title(announcementSaveRequest.title())
+                .description(announcementSaveRequest.description())
+                .build();
+
+        if(imageFiles != null && !imageFiles.isEmpty()) {
+            List<ImageFileDto> uploadedImages = uploadImages(imageFiles);
+            saveImageFiles(uploadedImages, announcement);
+        }
+
+        Announcement saveAnnouncement = announcementRepository.save(announcement);
+        return createAnnouncementResponseDto(saveAnnouncement, user);
+    }
+
+    private List<ImageFileDto> uploadImages(List<MultipartFile> imageFiles) {
+        List<ImageFileDto> uploadedImages = new ArrayList<>();
+
+        for (MultipartFile file : imageFiles) {
+            // 이미지 파일 확인
+            if(!s3Service.checkImageFile(file)) {
+                throw new IllegalArgumentException("이미지 파일만 업로드 가능합니다.");
+            }
+
+            // S3에 파일 업로드
+            S3Response s3Response = s3Service.saveFileWithUUID(file, "qna");
+
+            // 파일 타입 결정(확장자 기반)
+            String contentType = file.getContentType();
+            ImageFileType fileType = contentType != null && contentType.contains("png")
+                    ? ImageFileType.PNG : ImageFileType.JPEG;
+
+            // ImageFileDto 생성 및 리스트에 추가
+            uploadedImages.add(new ImageFileDto(0L,
+                    fileType,
+                    s3Response.filePath(),
+                    s3Response.s3ImageUrl()
+            ));
+        }
+
+        return uploadedImages;
+    }
+
+    public AllAnnouncementResponse getAllAnnouncement(int pageSize, Long announcementId, String title, SortBy sortBy, User currentUser) {
+        List<Announcement> allAnnouncement = announcementRepository.paginationNoOffset(announcementId, title, pageSize, sortBy);
+
+        List<AnnouncementPaginationResponse> announcementPaginationResponseList = allAnnouncement.stream()
+                .map(announcement -> {
+                    String thumbnailImageUrl = announcement.getImageUrls() != null && !announcement.getImageUrls().isEmpty()
+                            ? announcement.getImageUrls().get(0).getImageUrl()
+                            : "";
+                    return AnnouncementPaginationResponse.of(
+                            announcement.getId(),
+                            announcement.getWriter().getUuid().toString(),
+                            announcement.getWriter().getUsername(),
+                            announcement.getWriter().getProfileImageUrl() != null ? announcement.getWriter().getProfileImageUrl() : "",
+                            announcement.getTitle(),
+                            announcement.getDescription(),
+                            announcement.getViewCount(),
+                            announcement.getCreatedDate(),
+                            announcement.getLastModifiedDate(),
+                            thumbnailImageUrl
+
+                    );
+                })
+                .toList();
+
+        Long nextId = getNextId(announcementPaginationResponseList, pageSize);
+
+        return AllAnnouncementResponse.of(nextId, announcementPaginationResponseList);
+    }
+
+    private Long getNextId(List<AnnouncementPaginationResponse> responses, int pageSize) {
+        if(responses.isEmpty() || responses.size() < pageSize) {
+            return -1L;
+        }
+
+        return responses.stream()
+                .map(AnnouncementPaginationResponse::id)
+                .reduce((first, second) -> second) // 마지막 ID를 반환
+                .orElse(-1L); // 리스트가 비어었으면 -1 반환
+    }
+
+    @Transactional
+    public AnnouncementResponse getAnnouncement(Long announcementId, User currentUser) {
+        Announcement announcementById = findAnnouncementById(announcementId);
+
+        announcementById.plusViewCount();
+        return createAnnouncementResponseDto(announcementById, currentUser);
+    }
+
+    @Transactional
+    public AnnouncementResponse updateAnnouncement(Long announcementId, AnnouncementUpdateRequest announcementUpdateRequest, List<MultipartFile> newFiles, User user) {
+        Announcement announcementById = findAnnouncementById(announcementId);
+        isAnnouncementWriter(user, announcementById);
+
+        int currentImageCount = announcementById.getImageUrls().size();
+        int deletedImageCount = (announcementUpdateRequest.deleteImageIds() != null) ? announcementUpdateRequest.deleteImageIds().size() : 0;
+        int newImageCount = (newFiles != null) ? newFiles.size() : 0;
+        int finalImageCount = currentImageCount - deletedImageCount + newImageCount;
+
+        if (finalImageCount > MAX_ANNOUNCEMENT_IMAGES) {
+            throw new BadRequestException("공지사항 게시글에는 이미지를 최대 " + MAX_ANNOUNCEMENT_IMAGES + "개까지 첨부할 수 있습니다. (현재 " + finalImageCount + "개)");
+        }
+
+        if (announcementUpdateRequest.deleteImageIds() != null && !announcementUpdateRequest.deleteImageIds().isEmpty()) {
+            deleteImages(announcementId, announcementUpdateRequest.deleteImageIds(), user);
+        }
+
+        if (newFiles != null && !newFiles.isEmpty()) {
+            List<ImageFileDto> uploadedImages = uploadImages(newFiles);
+            saveImageFiles(uploadedImages, announcementById);
+        }
+
+        announcementById.update(announcementUpdateRequest.title(), announcementUpdateRequest.description());
+        return createAnnouncementResponseDto(announcementById, user);
+    }
+
+    private static void isAnnouncementWriter(User user, Announcement announcementById) {
+        if (!Objects.equals(announcementById.getWriter().getUuid(), user.getUuid())) {
+            throw new NotWriterException();
+        }
+    }
+
+    @Transactional
+    public void deleteImages(Long announcementId, List<Long> imageIds, User user) {
+        Announcement announcement = findAnnouncementById(announcementId);
+        isAnnouncementWriter(user, announcement);
+        for (Long imageId : imageIds) {
+            announcement.deleteImage(imageId);
+            AnnouncementImage announcementImage = announcementImageRepository.findById(imageId).orElseThrow(AnnouncementImageNotFoundException::new);
+            //s3에서도 이미지 삭제
+            s3Service.deleteFile(announcementImage.getImageUrl());
+        }
+    }
+
+    @Transactional
+    public void deleteAnnouncement(Long announcementId, User user) {
+        Announcement announcement = findAnnouncementById(announcementId);
+        // 해당 게시글 작성자가 아닐 경우
+        isAnnouncementWriter(user, announcement);
+
+        // 게시글에 첨부된 이미지들도 S3에서 삭제
+        List<AnnouncementImage> images = announcement.getImageUrls();
+        for(AnnouncementImage image : images) {
+            s3Service.deleteFile(image.getFilePath());
+        }
+        announcementRepository.delete(announcement);
+    }
+
+    private AnnouncementResponse createAnnouncementResponseDto(Announcement announcement, User currentUser){
+        List<ImageFileDto> images = announcement.getImageUrls()
+                .stream()
+                .map(announcementImage -> ImageFileDto.of(announcementImage.getId(), announcementImage.getFileType(), announcementImage.getFilePath(),
+                        announcementImage.getImageUrl()))
+                .toList();
+
+        return AnnouncementResponse.of(
+                announcement.getId(),
+                announcement.getWriter().getUuid().toString(),
+                announcement.getWriter().getUsername(),
+                announcement.getWriter().getProfileImageUrl() != null ? announcement.getWriter().getProfileImageUrl() : "",
+                announcement.getTitle(),
+                announcement.getDescription(),
+                announcement.getViewCount(),
+                announcement.getCreatedDate(),
+                announcement.getLastModifiedDate(),
+                images
+        );
+    }
+
+    private void saveImageFiles(List<ImageFileDto> imageFiles, Announcement announcement) {
+        for (ImageFileDto imageFile : imageFiles) {
+            AnnouncementImage announcementImage = AnnouncementImage.builder()
+                    .announcement(announcement)
+                    .imageUrl(imageFile.url())
+                    .filePath(imageFile.name())
+                    .fileType(imageFile.type())
+                    .build();
+            announcement.addImage(announcementImage);
+        }
+    }
+
+    public Announcement findAnnouncementById(Long announcementId) {
+        return announcementRepository.findById(announcementId).orElseThrow(AnnouncementNotFoundException::new);
+    }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 }

--- a/src/main/java/com/example/kbuddy_backend/announcement/service/AnnouncementService.java
+++ b/src/main/java/com/example/kbuddy_backend/announcement/service/AnnouncementService.java
@@ -1,0 +1,4 @@
+package com.example.kbuddy_backend.announcement.service;
+
+public class AnnouncementService {
+}


### PR DESCRIPTION
## Description (요약)
공지사항 작성, 조회, 수정, 삭제 구현


## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)
Swagger(jwt test token)

## Major Changes (주요 변경사항)
1. 작성 시 Multipart/form-data 형식으로 게시글과 이미지(최대 5개, 선택사항)를 함께 전송하여 생성
2. 제목/내용 null 이거나(@Notnull) 빈 문자열 일 때(Service 레벨 검증) 에러 발생, 제목은 100자로 제한(@Size(max = 100))
3. 존재하지 않는 공지사항 게시글 조회 시 에러 발생
4. 공지글이므로 기존 Blog, QnA와 다르게 댓글, 북마크, 카테고리, 신고 기능 제외
5. 전체 조회 시 최신순 정렬 지원(SortBy 파라미터로 정렬 옵션 제공, 기본 값: 최신순)
6. 조회수 기능 구현(단건 조회 시 자동 증가)
7. 수정 기능: 제목/내용 수정 및 이미지 추가/삭제 지원 (이미지 개수 제한: 최대 5개)
8. 삭제 기능: 작성자만 삭제 가능, 게시글 삭제 시 S3에 저장된 이미지도 함께 삭제
9. 작성자 검증: 수정/삭제 시 작성자만 가능하도록 검증 (NotWriterException)
10. 페이징 기능: No-Offset 방식의 커서 기반 페이징 구현
11. 키워드 검색: 제목 기반 키워드 검색 기능

## Exception Handling
- `AnnouncementNotFoundException` - 존재하지 않는 공지사항 조회/수정/삭제 시
- `NotWriterException` - 작성자가 아닌 사용자의 수정/삭제 시도 시
- `AnnouncementImageNotFoundException` - 존재하지 않는 이미지 삭제 시도 시
- `BadRequestException` - 유효성 검증 실패 시 (제목/내용 비어있음, 이미지 개수 초과 등)

## Etc (비고)