### PR TITLE
[FEAT] 가입자 수, 이메일, 성별 통계 관리자 페이지

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/admin/config/AdminCredentialsProperties.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/config/AdminCredentialsProperties.java
@@ -1,0 +1,23 @@
+package com.example.kbuddy_backend.admin.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "admin.credentials")
+public class AdminCredentialsProperties {
+
+    private String id;
+    private String password;
+
+    public boolean isConfigured() {
+        return StringUtils.hasText(id) && StringUtils.hasText(password);
+    }
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/controller/AdminDashboardController.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/controller/AdminDashboardController.java
@@ -1,0 +1,46 @@
+package com.example.kbuddy_backend.admin.controller;
+
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedPostsResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedUsersResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminSubscriberListResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminSubscriberStatsResponse;
+import com.example.kbuddy_backend.admin.service.AdminDashboardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin")
+public class AdminDashboardController {
+
+    private final AdminDashboardService adminDashboardService;
+
+    @GetMapping("/subscribers/stats")
+    public ResponseEntity<AdminSubscriberStatsResponse> getSubscriberStats() {
+        return ResponseEntity.ok(adminDashboardService.getSubscriberStats());
+    }
+
+    @GetMapping("/subscribers/list")
+    public ResponseEntity<AdminSubscriberListResponse> getSubscribers(
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable
+    ) {
+        return ResponseEntity.ok(adminDashboardService.getSubscribers(pageable));
+    }
+
+    @GetMapping("/reports/users")
+    public ResponseEntity<AdminReportedUsersResponse> getReportedUsers() {
+        return ResponseEntity.ok(adminDashboardService.getReportedUsers());
+    }
+
+    @GetMapping("/reports/posts")
+    public ResponseEntity<AdminReportedPostsResponse> getReportedPosts() {
+        return ResponseEntity.ok(adminDashboardService.getReportedPosts());
+    }
+}
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/AdminPostType.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/AdminPostType.java
@@ -1,0 +1,8 @@
+package com.example.kbuddy_backend.admin.dto;
+
+public enum AdminPostType {
+    BLOG,
+    QNA
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedPostResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedPostResponse.java
@@ -1,0 +1,20 @@
+package com.example.kbuddy_backend.admin.dto.response;
+
+import com.example.kbuddy_backend.admin.dto.AdminPostType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminReportedPostResponse {
+
+    private final AdminPostType postType;
+    private final Long postId;
+    private final String title;
+    private final Long writerId;
+    private final String writerUsername;
+    private final String writerEmail;
+    private final long reportCount;
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedPostsResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedPostsResponse.java
@@ -1,0 +1,15 @@
+package com.example.kbuddy_backend.admin.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminReportedPostsResponse {
+
+    private final int totalPosts;
+    private final List<AdminReportedPostResponse> posts;
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedUserResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedUserResponse.java
@@ -1,0 +1,18 @@
+package com.example.kbuddy_backend.admin.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminReportedUserResponse {
+
+    private final Long userId;
+    private final String username;
+    private final String email;
+    private final long totalReports;
+    private final List<AdminReportedPostResponse> posts;
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedUsersResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminReportedUsersResponse.java
@@ -1,0 +1,15 @@
+package com.example.kbuddy_backend.admin.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminReportedUsersResponse {
+
+    private final int totalUsers;
+    private final List<AdminReportedUserResponse> users;
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminSubscriberDetailResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminSubscriberDetailResponse.java
@@ -1,0 +1,20 @@
+package com.example.kbuddy_backend.admin.dto.response;
+
+import com.example.kbuddy_backend.user.constant.Gender;
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminSubscriberDetailResponse {
+
+    private final Long userId;
+    private final String username;
+    private final String email;
+    private final Gender gender;
+    private final boolean active;
+    private final LocalDateTime createdAt;
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminSubscriberListResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminSubscriberListResponse.java
@@ -1,0 +1,17 @@
+package com.example.kbuddy_backend.admin.dto.response;
+
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminSubscriberListResponse {
+
+    private final long totalElements;
+    private final int page;
+    private final int size;
+    private final List<AdminSubscriberDetailResponse> subscribers;
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminSubscriberStatsResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/dto/response/AdminSubscriberStatsResponse.java
@@ -1,0 +1,15 @@
+package com.example.kbuddy_backend.admin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminSubscriberStatsResponse {
+
+    private final long totalSubscribers;
+    private final long maleSubscribers;
+    private final long femaleSubscribers;
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/filter/AdminBasicAuthFilter.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/filter/AdminBasicAuthFilter.java
@@ -1,0 +1,103 @@
+package com.example.kbuddy_backend.admin.filter;
+
+import com.example.kbuddy_backend.admin.config.AdminCredentialsProperties;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.Collections;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@Component
+@RequiredArgsConstructor
+public class AdminBasicAuthFilter extends OncePerRequestFilter {
+
+    private static final String ADMIN_REALM = "KBuddy Admin";
+    private final AdminCredentialsProperties credentialsProperties;
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) {
+        final String uri = request.getRequestURI();
+        return uri == null || !uri.startsWith("/admin");
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        if (!credentialsProperties.isConfigured()) {
+            reject(response);
+            return;
+        }
+
+        String header = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (header == null || !header.startsWith("Basic ")) {
+            reject(response);
+            return;
+        }
+
+        String decoded;
+        try {
+            decoded = new String(Base64.getDecoder().decode(header.substring(6).trim()), StandardCharsets.UTF_8);
+        } catch (IllegalArgumentException ex) {
+            reject(response);
+            return;
+        }
+
+        int separatorIndex = decoded.indexOf(':');
+        if (separatorIndex < 0) {
+            reject(response);
+            return;
+        }
+
+        String inputId = decoded.substring(0, separatorIndex);
+        String inputPassword = decoded.substring(separatorIndex + 1);
+
+        if (!constantTimeEquals(credentialsProperties.getId(), inputId)
+                || !constantTimeEquals(credentialsProperties.getPassword(), inputPassword)) {
+            reject(response);
+            return;
+        }
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                "ADMIN",
+                null,
+                Collections.singletonList(new SimpleGrantedAuthority("ROLE_ADMIN"))
+        );
+        SecurityContextHolder.getContextHolderStrategy().getContext().setAuthentication(authentication);
+        filterChain.doFilter(request, response);
+    }
+
+    private boolean constantTimeEquals(String expected, String actual) {
+        if (expected == null || actual == null) {
+            return false;
+        }
+        byte[] expectedBytes = expected.getBytes(StandardCharsets.UTF_8);
+        byte[] actualBytes = actual.getBytes(StandardCharsets.UTF_8);
+        if (expectedBytes.length != actualBytes.length) {
+            return false;
+        }
+
+        int result = 0;
+        for (int i = 0; i < expectedBytes.length; i++) {
+            result |= expectedBytes[i] ^ actualBytes[i];
+        }
+        return result == 0;
+    }
+
+    private void reject(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setHeader(HttpHeaders.WWW_AUTHENTICATE, "Basic realm=\"" + ADMIN_REALM + "\"");
+        response.getWriter().write("Unauthorized");
+    }
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/admin/service/AdminDashboardService.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/service/AdminDashboardService.java
@@ -1,0 +1,139 @@
+package com.example.kbuddy_backend.admin.service;
+
+import com.example.kbuddy_backend.admin.dto.AdminPostType;
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedPostResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedPostsResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedUserResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedUsersResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminSubscriberDetailResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminSubscriberListResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminSubscriberStatsResponse;
+import com.example.kbuddy_backend.blog.repository.BlogReportRepository;
+import com.example.kbuddy_backend.blog.repository.BlogReportSummary;
+import com.example.kbuddy_backend.qna.repository.QnaReportRepository;
+import com.example.kbuddy_backend.qna.repository.QnaReportSummary;
+import com.example.kbuddy_backend.user.constant.Gender;
+import com.example.kbuddy_backend.user.entity.User;
+import com.example.kbuddy_backend.user.repository.UserRepository;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminDashboardService {
+
+    private final UserRepository userRepository;
+    private final BlogReportRepository blogReportRepository;
+    private final QnaReportRepository qnaReportRepository;
+
+    public AdminSubscriberStatsResponse getSubscriberStats() {
+        long total = userRepository.count();
+        long male = userRepository.countByGender(Gender.M);
+        long female = userRepository.countByGender(Gender.F);
+        return AdminSubscriberStatsResponse.builder()
+                .totalSubscribers(total)
+                .maleSubscribers(male)
+                .femaleSubscribers(female)
+                .build();
+    }
+
+    public AdminSubscriberListResponse getSubscribers(Pageable pageable) {
+        Page<User> page = userRepository.findAll(pageable);
+        List<AdminSubscriberDetailResponse> subscribers = page.getContent().stream()
+                .map(user -> AdminSubscriberDetailResponse.builder()
+                        .userId(user.getId())
+                        .username(user.getUsername())
+                        .email(user.getEmail())
+                        .gender(user.getGender())
+                        .active(user.isActive())
+                        .createdAt(user.getCreatedDate())
+                        .build())
+                .toList();
+
+        return AdminSubscriberListResponse.builder()
+                .totalElements(page.getTotalElements())
+                .page(page.getNumber())
+                .size(page.getSize())
+                .subscribers(subscribers)
+                .build();
+    }
+
+    public AdminReportedPostsResponse getReportedPosts() {
+        List<AdminReportedPostResponse> posts = collectReportedPosts();
+        posts.sort(Comparator.comparingLong(AdminReportedPostResponse::getReportCount).reversed());
+        return AdminReportedPostsResponse.builder()
+                .totalPosts(posts.size())
+                .posts(posts)
+                .build();
+    }
+
+    public AdminReportedUsersResponse getReportedUsers() {
+        List<AdminReportedPostResponse> posts = collectReportedPosts();
+        Map<Long, List<AdminReportedPostResponse>> groupedByUser = posts.stream()
+                .collect(Collectors.groupingBy(AdminReportedPostResponse::getWriterId));
+
+        List<AdminReportedUserResponse> users = groupedByUser.values().stream()
+                .map(userPosts -> {
+                    AdminReportedPostResponse representative = userPosts.get(0);
+                    long totalReports = userPosts.stream()
+                            .mapToLong(AdminReportedPostResponse::getReportCount)
+                            .sum();
+                    return AdminReportedUserResponse.builder()
+                            .userId(representative.getWriterId())
+                            .username(representative.getWriterUsername())
+                            .email(representative.getWriterEmail())
+                            .totalReports(totalReports)
+                            .posts(userPosts.stream()
+                                    .sorted(Comparator.comparingLong(AdminReportedPostResponse::getReportCount).reversed())
+                                    .toList())
+                            .build();
+                })
+                .sorted(Comparator.comparingLong(AdminReportedUserResponse::getTotalReports).reversed())
+                .toList();
+
+        return AdminReportedUsersResponse.builder()
+                .totalUsers(users.size())
+                .users(users)
+                .build();
+    }
+
+    private List<AdminReportedPostResponse> collectReportedPosts() {
+        List<AdminReportedPostResponse> posts = new ArrayList<>();
+        List<BlogReportSummary> blogSummaries = blogReportRepository.findReportSummaries();
+        for (BlogReportSummary summary : blogSummaries) {
+            posts.add(AdminReportedPostResponse.builder()
+                    .postType(AdminPostType.BLOG)
+                    .postId(summary.getBlogId())
+                    .title(summary.getBlogTitle())
+                    .writerId(summary.getWriterId())
+                    .writerUsername(summary.getWriterUsername())
+                    .writerEmail(summary.getWriterEmail())
+                    .reportCount(summary.getReportCount())
+                    .build());
+        }
+
+        List<QnaReportSummary> qnaSummaries = qnaReportRepository.findReportSummaries();
+        for (QnaReportSummary summary : qnaSummaries) {
+            posts.add(AdminReportedPostResponse.builder()
+                    .postType(AdminPostType.QNA)
+                    .postId(summary.getQnaId())
+                    .title(summary.getQnaTitle())
+                    .writerId(summary.getWriterId())
+                    .writerUsername(summary.getWriterUsername())
+                    .writerEmail(summary.getWriterEmail())
+                    .reportCount(summary.getReportCount())
+                    .build());
+        }
+        return posts;
+    }
+}
+

--- a/src/main/java/com/example/kbuddy_backend/blog/repository/BlogReportRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/repository/BlogReportRepository.java
@@ -3,8 +3,22 @@ package com.example.kbuddy_backend.blog.repository;
 import com.example.kbuddy_backend.blog.entity.BlogReport;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface BlogReportRepository extends JpaRepository<BlogReport, Long> {
     boolean existsByBlogIdAndReporterId(Long blogId, Long reportedId);
     List<BlogReport> findAllByBlogId(Long blogId);
+
+    @Query("""
+            select br.blog.id as blogId,
+                   br.blog.title as blogTitle,
+                   br.blog.writer.id as writerId,
+                   br.blog.writer.username as writerUsername,
+                   br.blog.writer.email as writerEmail,
+                   count(br.id) as reportCount
+            from BlogReport br
+            group by br.blog.id, br.blog.title, br.blog.writer.id, br.blog.writer.username, br.blog.writer.email
+            order by count(br.id) desc
+            """)
+    List<BlogReportSummary> findReportSummaries();
 }

--- a/src/main/java/com/example/kbuddy_backend/blog/repository/BlogReportSummary.java
+++ b/src/main/java/com/example/kbuddy_backend/blog/repository/BlogReportSummary.java
@@ -1,0 +1,18 @@
+package com.example.kbuddy_backend.blog.repository;
+
+public interface BlogReportSummary {
+
+    Long getBlogId();
+
+    String getBlogTitle();
+
+    Long getWriterId();
+
+    String getWriterUsername();
+
+    String getWriterEmail();
+
+    Long getReportCount();
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.kbuddy_backend.common.config;
 
+import com.example.kbuddy_backend.admin.filter.AdminBasicAuthFilter;
 import com.example.kbuddy_backend.auth.config.JwtAccessDeniedHandler;
 import com.example.kbuddy_backend.auth.config.JwtAuthenticationEntryPoint;
 import com.example.kbuddy_backend.auth.config.JwtFilter;
@@ -27,6 +28,7 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtTokenProvider tokenProvider;
+    private final AdminBasicAuthFilter adminBasicAuthFilter;
 
     //시큐리티를 적용하지 않을 리소스
     @Bean
@@ -47,6 +49,7 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(adminBasicAuthFilter, JwtFilter.class)
                 .exceptionHandling(exceptionHandling -> {
                     exceptionHandling
                             .authenticationEntryPoint(jwtAuthenticationEntryPoint)

--- a/src/main/java/com/example/kbuddy_backend/qna/repository/QnaReportRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/repository/QnaReportRepository.java
@@ -1,11 +1,24 @@
 package com.example.kbuddy_backend.qna.repository;
 
 import com.example.kbuddy_backend.qna.entity.QnaReport;
-import org.springframework.data.jpa.repository.JpaRepository;
-
 import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 public interface QnaReportRepository extends JpaRepository<QnaReport, Long> {
     boolean existsByQnaIdAndReporterId(Long qnaId, Long reportId);
     List<QnaReport> findAllByQnaId(Long qnaId);
+
+    @Query("""
+            select qr.qna.id as qnaId,
+                   qr.qna.title as qnaTitle,
+                   qr.qna.writer.id as writerId,
+                   qr.qna.writer.username as writerUsername,
+                   qr.qna.writer.email as writerEmail,
+                   count(qr.id) as reportCount
+            from QnaReport qr
+            group by qr.qna.id, qr.qna.title, qr.qna.writer.id, qr.qna.writer.username, qr.qna.writer.email
+            order by count(qr.id) desc
+            """)
+    List<QnaReportSummary> findReportSummaries();
 }

--- a/src/main/java/com/example/kbuddy_backend/qna/repository/QnaReportSummary.java
+++ b/src/main/java/com/example/kbuddy_backend/qna/repository/QnaReportSummary.java
@@ -1,0 +1,18 @@
+package com.example.kbuddy_backend.qna.repository;
+
+public interface QnaReportSummary {
+
+    Long getQnaId();
+
+    String getQnaTitle();
+
+    Long getWriterId();
+
+    String getWriterUsername();
+
+    String getWriterEmail();
+
+    Long getReportCount();
+}
+
+

--- a/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/user/repository/UserRepository.java
@@ -1,10 +1,10 @@
 package com.example.kbuddy_backend.user.repository;
 
+import com.example.kbuddy_backend.user.constant.Gender;
 import com.example.kbuddy_backend.user.constant.OAuthCategory;
 import com.example.kbuddy_backend.user.entity.User;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface UserRepository extends JpaRepository<User, Long> {
@@ -20,4 +20,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByUsernameOrEmailAndOauthCategoryIsNullAndOauthUidIsNull(String emailOrUserId, String emailOrUserId1);
 
     Optional<User> findByUuid(UUID uuid);
+
+    long countByGender(Gender gender);
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   profiles:
     active: dev # 또는 원하는 profile 이름
+admin:
+  credentials:
+    id: ${ADMIN_BASIC_ID:admin}
+    password: ${ADMIN_BASIC_PASSWORD:change-me}

--- a/src/test/java/com/example/kbuddy_backend/admin/filter/AdminBasicAuthFilterTest.java
+++ b/src/test/java/com/example/kbuddy_backend/admin/filter/AdminBasicAuthFilterTest.java
@@ -1,0 +1,78 @@
+package com.example.kbuddy_backend.admin.filter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.example.kbuddy_backend.admin.config.AdminCredentialsProperties;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockFilterChain;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+class AdminBasicAuthFilterTest {
+
+    private AdminCredentialsProperties properties;
+    private AdminBasicAuthFilter filter;
+
+    @BeforeEach
+    void setUp() {
+        properties = new AdminCredentialsProperties();
+        properties.setId("admin");
+        properties.setPassword("password");
+        filter = new AdminBasicAuthFilter(properties);
+        SecurityContextHolder.clearContext();
+    }
+
+    @DisplayName("관리자 경로가 아니면 필터가 동작하지 않는다")
+    @Test
+    void shouldSkipNonAdminPath() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/kbuddy/v1/blog");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @DisplayName("Basic Auth 헤더가 없으면 401을 반환한다")
+    @Test
+    void shouldRejectMissingHeader() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/admin/subscribers/stats");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(401);
+    }
+
+    @DisplayName("정상 자격 증명으로 요청하면 인증이 설정된다")
+    @Test
+    void shouldAuthenticateWithValidCredentials() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/admin/subscribers/stats");
+        String encoded = Base64.getEncoder()
+                .encodeToString("admin:password".getBytes(StandardCharsets.UTF_8));
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + encoded);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertThat(response.getStatus()).isEqualTo(200);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getAuthorities())
+                .extracting("authority")
+                .contains("ROLE_ADMIN");
+    }
+}
+
+

--- a/src/test/java/com/example/kbuddy_backend/admin/service/AdminDashboardServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/admin/service/AdminDashboardServiceTest.java
@@ -1,0 +1,187 @@
+package com.example.kbuddy_backend.admin.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.example.kbuddy_backend.admin.dto.AdminPostType;
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedPostsResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminReportedUsersResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminSubscriberListResponse;
+import com.example.kbuddy_backend.admin.dto.response.AdminSubscriberStatsResponse;
+import com.example.kbuddy_backend.blog.repository.BlogReportRepository;
+import com.example.kbuddy_backend.blog.repository.BlogReportSummary;
+import com.example.kbuddy_backend.qna.repository.QnaReportRepository;
+import com.example.kbuddy_backend.qna.repository.QnaReportSummary;
+import com.example.kbuddy_backend.user.constant.Gender;
+import com.example.kbuddy_backend.user.entity.User;
+import com.example.kbuddy_backend.user.repository.UserRepository;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AdminDashboardServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private BlogReportRepository blogReportRepository;
+    @Mock
+    private QnaReportRepository qnaReportRepository;
+
+    private AdminDashboardService adminDashboardService;
+
+    @BeforeEach
+    void setUp() {
+        adminDashboardService = new AdminDashboardService(userRepository, blogReportRepository, qnaReportRepository);
+    }
+
+    @DisplayName("구독자 통계 조회 시 전체·성별 수를 반환한다")
+    @Test
+    void getSubscriberStats() {
+        given(userRepository.count()).willReturn(10L);
+        given(userRepository.countByGender(Gender.M)).willReturn(6L);
+        given(userRepository.countByGender(Gender.F)).willReturn(4L);
+
+        AdminSubscriberStatsResponse response = adminDashboardService.getSubscriberStats();
+
+        assertThat(response.getTotalSubscribers()).isEqualTo(10);
+        assertThat(response.getMaleSubscribers()).isEqualTo(6);
+        assertThat(response.getFemaleSubscribers()).isEqualTo(4);
+    }
+
+    @DisplayName("구독자 목록 조회 시 페이지 정보와 사용자 정보가 매핑된다")
+    @Test
+    void getSubscribers() {
+        User user = User.builder()
+                .username("tester")
+                .email("tester@example.com")
+                .gender(Gender.M)
+                .build();
+        ReflectionTestUtils.setField(user, "id", 1L);
+        ReflectionTestUtils.setField(user, "isActive", true);
+        ReflectionTestUtils.setField(user, "createdDate", LocalDateTime.now());
+
+        PageRequest pageable = PageRequest.of(0, 20);
+        given(userRepository.findAll(any()))
+                .willReturn(new PageImpl<>(List.of(user), pageable, 1));
+
+        AdminSubscriberListResponse response = adminDashboardService.getSubscribers(pageable);
+
+        assertThat(response.getTotalElements()).isEqualTo(1);
+        assertThat(response.getSubscribers()).hasSize(1);
+        assertThat(response.getSubscribers().get(0).getUsername()).isEqualTo("tester");
+    }
+
+    @DisplayName("신고된 게시물 목록 조회 시 블로그와 QnA가 함께 포함된다")
+    @Test
+    void getReportedPosts() {
+        BlogReportSummary blogSummary = mockBlogSummary(1L, "blog title", 10L, "blogger", "blogger@mail.com", 3L);
+        QnaReportSummary qnaSummary = mockQnaSummary(2L, "qna title", 20L, "qnaer", "qnaer@mail.com", 2L);
+
+        given(blogReportRepository.findReportSummaries()).willReturn(List.of(blogSummary));
+        given(qnaReportRepository.findReportSummaries()).willReturn(List.of(qnaSummary));
+
+        AdminReportedPostsResponse response = adminDashboardService.getReportedPosts();
+
+        assertThat(response.getTotalPosts()).isEqualTo(2);
+        assertThat(response.getPosts())
+                .anyMatch(post -> post.getPostType() == AdminPostType.BLOG && post.getReportCount() == 3);
+        assertThat(response.getPosts())
+                .anyMatch(post -> post.getPostType() == AdminPostType.QNA && post.getReportCount() == 2);
+    }
+
+    @DisplayName("신고된 사용자 목록 조회 시 사용자별 신고 수가 합산된다")
+    @Test
+    void getReportedUsers() {
+        BlogReportSummary blogSummary = mockBlogSummary(1L, "blog title", 10L, "reportee", "user@mail.com", 3L);
+        QnaReportSummary qnaSummary = mockQnaSummary(2L, "qna title", 10L, "reportee", "user@mail.com", 2L);
+
+        given(blogReportRepository.findReportSummaries()).willReturn(List.of(blogSummary));
+        given(qnaReportRepository.findReportSummaries()).willReturn(List.of(qnaSummary));
+
+        AdminReportedUsersResponse response = adminDashboardService.getReportedUsers();
+
+        assertThat(response.getTotalUsers()).isEqualTo(1);
+        assertThat(response.getUsers().get(0).getTotalReports()).isEqualTo(5);
+        assertThat(response.getUsers().get(0).getPosts()).hasSize(2);
+    }
+
+    private BlogReportSummary mockBlogSummary(Long blogId, String title, Long writerId, String username, String email, Long count) {
+        return new BlogReportSummary() {
+            @Override
+            public Long getBlogId() {
+                return blogId;
+            }
+
+            @Override
+            public String getBlogTitle() {
+                return title;
+            }
+
+            @Override
+            public Long getWriterId() {
+                return writerId;
+            }
+
+            @Override
+            public String getWriterUsername() {
+                return username;
+            }
+
+            @Override
+            public String getWriterEmail() {
+                return email;
+            }
+
+            @Override
+            public Long getReportCount() {
+                return count;
+            }
+        };
+    }
+
+    private QnaReportSummary mockQnaSummary(Long qnaId, String title, Long writerId, String username, String email, Long count) {
+        return new QnaReportSummary() {
+            @Override
+            public Long getQnaId() {
+                return qnaId;
+            }
+
+            @Override
+            public String getQnaTitle() {
+                return title;
+            }
+
+            @Override
+            public Long getWriterId() {
+                return writerId;
+            }
+
+            @Override
+            public String getWriterUsername() {
+                return username;
+            }
+
+            @Override
+            public String getWriterEmail() {
+                return email;
+            }
+
+            @Override
+            public Long getReportCount() {
+                return count;
+            }
+        };
+    }
+}
+

--- a/src/test/java/com/example/kbuddy_backend/admin/service/AdminDashboardServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/admin/service/AdminDashboardServiceTest.java
@@ -26,6 +26,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -72,7 +73,7 @@ class AdminDashboardServiceTest {
         ReflectionTestUtils.setField(user, "createdDate", LocalDateTime.now());
 
         PageRequest pageable = PageRequest.of(0, 20);
-        given(userRepository.findAll(any()))
+        given(userRepository.findAll(any(Pageable.class)))
                 .willReturn(new PageImpl<>(List.of(user), pageable, 1));
 
         AdminSubscriberListResponse response = adminDashboardService.getSubscribers(pageable);
@@ -116,7 +117,8 @@ class AdminDashboardServiceTest {
         assertThat(response.getUsers().get(0).getPosts()).hasSize(2);
     }
 
-    private BlogReportSummary mockBlogSummary(Long blogId, String title, Long writerId, String username, String email, Long count) {
+    private BlogReportSummary mockBlogSummary(Long blogId, String title, Long writerId, String username, String email,
+            Long count) {
         return new BlogReportSummary() {
             @Override
             public Long getBlogId() {
@@ -150,7 +152,8 @@ class AdminDashboardServiceTest {
         };
     }
 
-    private QnaReportSummary mockQnaSummary(Long qnaId, String title, Long writerId, String username, String email, Long count) {
+    private QnaReportSummary mockQnaSummary(Long qnaId, String title, Long writerId, String username, String email,
+            Long count) {
         return new QnaReportSummary() {
             @Override
             public Long getQnaId() {
@@ -184,4 +187,3 @@ class AdminDashboardServiceTest {
         };
     }
 }
-

--- a/src/test/java/com/example/kbuddy_backend/common/WebMVCTest.java
+++ b/src/test/java/com/example/kbuddy_backend/common/WebMVCTest.java
@@ -17,11 +17,10 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.annotation.RestController;
 
-@WebMvcTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = RestController.class),
-        excludeAutoConfiguration = {SecurityAutoConfiguration.class, WebSecurityConfiguration.class},
-        excludeFilters = {
-                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class)})
-@Import({JwtTokenProvider.class, MockedServiceClassBeanRegister.class})
+@WebMvcTest(includeFilters = @Filter(type = FilterType.ANNOTATION, classes = RestController.class), excludeAutoConfiguration = {
+        SecurityAutoConfiguration.class, WebSecurityConfiguration.class }, excludeFilters = {
+                @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class) })
+@Import({ JwtTokenProvider.class, MockedServiceClassBeanRegister.class })
 public abstract class WebMVCTest {
 
     @Autowired
@@ -35,4 +34,7 @@ public abstract class WebMVCTest {
 
     @MockBean
     protected UserRepository userRepository;
+
+    @MockBean
+    protected com.example.kbuddy_backend.admin.config.AdminCredentialsProperties adminCredentialsProperties;
 }


### PR DESCRIPTION
## Description (요약)
가입자 수, 가입자 이메일, 성별
신고 당한 사람, 그 사람의 게시물
api접근 했을때 id/password로 로그인해서 관리자 페이지 접근

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)


## Screenshots (optional)


## Etc (비고)