### PR TITLE
[FEAT] 채팅 웹소켓 엔드포인트에 JWT인증 추가

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/chat/base/websocket/WebSocketConfig.java
+++ b/src/main/java/com/example/kbuddy_backend/chat/base/websocket/WebSocketConfig.java
@@ -1,14 +1,27 @@
 package com.example.kbuddy_backend.chat.base.websocket;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.ChannelRegistration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.ChannelInterceptor;
+import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+import com.example.kbuddy_backend.auth.token.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.security.core.Authentication;
 
 @Configuration
 @EnableWebSocketMessageBroker
+@RequiredArgsConstructor
 public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
@@ -26,7 +39,34 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         // SockJS를 통한 웹소캣 연결 지원
         // stomp 접속 주소 url = ws://localhost:8080/ws, 프로토콜이 http가 아님
         registry.addEndpoint("/ws-stomp") // 처음 웹소켓 HandShake를 위한 접속 경로
-                .setAllowedOriginPatterns("*");
-//                .withSockJS();
+            .setAllowedOriginPatterns("*");
+        // .withSockJS();
+    }
+
+    @Override
+    public void configureClientInboundChannel(ChannelRegistration registration) {
+        registration.interceptors(new ChannelInterceptor() {
+            @Override
+            public Message<?> preSend(Message<?> message, MessageChannel channel) {
+                StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+
+                if (StompCommand.CONNECT.equals(accessor.getCommand())) {
+                    String jwt = accessor.getFirstNativeHeader("Authorization");
+                    if (jwt != null && jwt.startsWith("Bearer ")) {
+                        jwt = jwt.substring(7);
+                        if (jwtTokenProvider.validateToken(jwt)) {
+                            Authentication auth = jwtTokenProvider.getAuthentication(jwt);
+                            accessor.setUser(auth);
+                        } else {
+                            // 토큰이 유효하지 않은 경우 연결 거부
+                            throw new IllegalArgumentException("Invalid JWT token");
+                        }
+                    } else {
+                        throw new IllegalArgumentException("Authorization header missing or invalid");
+                    }
+                }
+                return message;
+            }
+        });
     }
 }


### PR DESCRIPTION
## Description (요약)


## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)
1. 도입 배경
보안 사각지대 존재: 기존 REST API는 Spring Security Filters를 통해 JWT 인증 했으나 웹소켓 엔드포인트는 별도의 보안 설정이 없어서 누구나 연결이 가능한 상태였습니다.
비인가 접근 위험: 악의적인 사용자가 인증 없이 채팅 서버에 접속하여 무작위로 메시지를 구독하거나 발행할 수 있습니다.
세션 내 사용자 식별 불가: 웹소켓 연결 시 인증 정보가 주입되지 않아서 서버 측에서 메시지를 보낸 주체가 누구인지 식별하거나 특정 사용자에게만 메시지를 전송하는 로직을 구현하는 데 한계가 있었습니다.

2. 사용 이유
기술 선택: Spring WebSocket의 ChannelInterceptor
사용 이유:
단순한 HTTP 핸드쉐이크 시점의 쿠키 인증보다 STOMP 프로토콜 레벨에서 명시적으로 헤더를 검증하는 것이 클라이언트 환경에 더 유연하게 대응할 수 있다고 판단했습니다.
기존에 구현된 JWT 토큰 검증 로직을 재사용하여 인증 정책의 일관성을 유지하고자 했습니다.
장점:
리소스 절약: 유효하지 않은 토큰으로 접근 시 연결 수립 단계에서 차단하여 불필요한 서버 리소스 낭비를 막습니다.
확장성: Interceptor 구조를 사용하므로 추후 로깅, 메시지 감시 등 추가적인 전처리 로직을 쉽게 붙일 수 있습니다.
단점:
클라이언트 구현 복잡도 증가: 프론트엔드에서 웹소켓 연결 시 HTTP 헤더뿐만 아니라 STOMP 헤더에도 Authorization 값을 실어 보내야 하는 추가 작업이 필요합니다.

3. 성과
보안 무결성 확보: 모든 실시간 채팅 연결에 대해 토큰 검증을 하여 익명/비인가 사용자의 접근을 차단했습니다.
데이터 신뢰성 향상: 웹소켓 세션에 인증된 사용자 정보가 정확히 연결되도록 하여 채팅 메시지 저장 시 작성자 위변조 가능성을 시스템 레벨에서 방지했습니다.
아키텍처 통일: REST API와 실시간 통신 간의 인증 방식을 JWT로 통일하여 보안 유지보수 비용을 줄였습니다.

## Screenshots (optional)


## Etc (비고)