### PR TITLE
[FEAT] 예약, 상담, 리뷰, 질의 API 개발

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/livechat/constant/BookingStatus.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/constant/BookingStatus.java
@@ -1,0 +1,16 @@
+package com.example.kbuddy_backend.livechat.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum BookingStatus {
+    PENDING("결제 대기"),
+    PAID("결제 완료"),
+    COMPLETED("상담 완료"),
+    CANCELLED("취소됨"),
+    REFUNDED("환불 완료");
+
+    private final String description;
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/constant/Specialty.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/constant/Specialty.java
@@ -1,0 +1,16 @@
+package com.example.kbuddy_backend.livechat.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum Specialty {
+    UNIVERSITY("대학 입학"),
+    CAREER("취업/커리어"),
+    VISA("비자/이민"),
+    LIFE("생활/정착"),
+    OTHER("기타");
+
+    private final String description;
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/controller/BookingController.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/controller/BookingController.java
@@ -1,0 +1,39 @@
+package com.example.kbuddy_backend.livechat.controller;
+
+import com.example.kbuddy_backend.common.config.CurrentUser;
+import com.example.kbuddy_backend.livechat.dto.request.BookingReserveRequest;
+import com.example.kbuddy_backend.livechat.dto.response.BookingReserveResponse;
+import com.example.kbuddy_backend.livechat.service.BookingService;
+import com.example.kbuddy_backend.user.entity.User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kbuddy/v1/booking")
+@Tag(name = "Booking API", description = "상담 예약 API")
+public class BookingController {
+
+    private final BookingService bookingService;
+
+    @PostMapping("/reserve")
+    @Operation(summary = "예약 선점", description = "상담 시간을 선점하고 결제 대기 상태로 전환합니다. 일정 시간 내 결제하지 않으면 자동 해제됩니다.")
+    public ResponseEntity<BookingReserveResponse> reserveBooking(
+            @Valid @RequestBody BookingReserveRequest request,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        BookingReserveResponse response = bookingService.reserve(user, request);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/controller/CounselorController.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/controller/CounselorController.java
@@ -1,0 +1,67 @@
+package com.example.kbuddy_backend.livechat.controller;
+
+import com.example.kbuddy_backend.common.config.CurrentUser;
+import com.example.kbuddy_backend.livechat.constant.Specialty;
+import com.example.kbuddy_backend.livechat.dto.response.CounselorAvailabilityResponse;
+import com.example.kbuddy_backend.livechat.dto.response.CounselorDetailResponse;
+import com.example.kbuddy_backend.livechat.dto.response.CounselorListResponse;
+import com.example.kbuddy_backend.livechat.service.CounselorProfileService;
+import com.example.kbuddy_backend.user.entity.User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kbuddy/v1/counselor")
+@Tag(name = "Counselor API", description = "상담사 조회 API")
+public class CounselorController {
+
+    private final CounselorProfileService counselorProfileService;
+
+    @GetMapping
+    @Operation(summary = "상담사 목록 조회", description = "상담사 목록을 페이징하여 조회합니다. specialty로 필터링 가능합니다.")
+    public ResponseEntity<CounselorListResponse> getCounselors(
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size,
+            @RequestParam(required = false) String specialty,
+            @RequestParam(required = false) String sort,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        Specialty specialtyEnum = specialty != null ? Specialty.valueOf(specialty) : null;
+        Pageable pageable = PageRequest.of(page, size);
+        CounselorListResponse response = counselorProfileService.getCounselors(specialtyEnum, sort, pageable);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{counselorId}")
+    @Operation(summary = "상담사 상세 조회", description = "상담사 프로필 상세 정보와 최근 리뷰를 조회합니다.")
+    public ResponseEntity<CounselorDetailResponse> getCounselor(
+            @PathVariable Long counselorId,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        CounselorDetailResponse response = counselorProfileService.getCounselor(counselorId);
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/{counselorId}/availability")
+    @Operation(summary = "상담 가능 시간 조회", description = "특정 월의 상담 가능 시간 슬롯을 조회합니다.")
+    public ResponseEntity<CounselorAvailabilityResponse> getAvailability(
+            @PathVariable Long counselorId,
+            @RequestParam int year,
+            @RequestParam int month,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        CounselorAvailabilityResponse response = counselorProfileService.getAvailability(counselorId, year, month);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/controller/CounselorReviewController.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/controller/CounselorReviewController.java
@@ -1,0 +1,52 @@
+package com.example.kbuddy_backend.livechat.controller;
+
+import com.example.kbuddy_backend.common.config.CurrentUser;
+import com.example.kbuddy_backend.livechat.dto.request.CreateInquiryRequest;
+import com.example.kbuddy_backend.livechat.dto.request.CreateReviewRequest;
+import com.example.kbuddy_backend.livechat.service.CounselorInquiryService;
+import com.example.kbuddy_backend.livechat.service.CounselorReviewService;
+import com.example.kbuddy_backend.user.entity.User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kbuddy/v1")
+@Tag(name = "Review & Inquiry API", description = "상담 리뷰 및 문의 API")
+public class CounselorReviewController {
+
+    private final CounselorReviewService counselorReviewService;
+    private final CounselorInquiryService counselorInquiryService;
+
+    @PostMapping("/review")
+    @Operation(summary = "리뷰 작성", description = "상담 완료 후 상담사에 대한 리뷰를 작성합니다.")
+    public ResponseEntity<Void> createReview(
+            @Valid @RequestBody CreateReviewRequest request,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        counselorReviewService.createReview(user, request);
+        return ResponseEntity.noContent().build();
+    }
+
+    @PostMapping("/counselor/{counselorId}/inquiry")
+    @Operation(summary = "문의글 작성", description = "상담사에게 문의글을 작성합니다. 비밀글로 설정할 수 있습니다.")
+    public ResponseEntity<Void> createInquiry(
+            @PathVariable Long counselorId,
+            @Valid @RequestBody CreateInquiryRequest request,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        counselorInquiryService.createInquiry(user, counselorId, request);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/dto/request/BookingReserveRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/dto/request/BookingReserveRequest.java
@@ -1,0 +1,8 @@
+package com.example.kbuddy_backend.livechat.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BookingReserveRequest(
+        @NotNull String counselorId,
+        @NotNull Long availabilityId) {
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/dto/request/CreateInquiryRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/dto/request/CreateInquiryRequest.java
@@ -1,0 +1,9 @@
+package com.example.kbuddy_backend.livechat.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record CreateInquiryRequest(
+        @NotBlank String title,
+        @NotBlank String content,
+        boolean isSecret) {
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/dto/request/CreateReviewRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/dto/request/CreateReviewRequest.java
@@ -1,0 +1,11 @@
+package com.example.kbuddy_backend.livechat.dto.request;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record CreateReviewRequest(
+        @NotNull Long bookingId,
+        @Min(1) @Max(5) int rating,
+        String comment) {
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/dto/response/BookingReserveResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/dto/response/BookingReserveResponse.java
@@ -1,0 +1,9 @@
+package com.example.kbuddy_backend.livechat.dto.response;
+
+import java.time.Instant;
+
+public record BookingReserveResponse(
+        Long bookingId,
+        String status,
+        Instant holdExpiresAt) {
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/dto/response/CounselorAvailabilityResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/dto/response/CounselorAvailabilityResponse.java
@@ -1,0 +1,15 @@
+package com.example.kbuddy_backend.livechat.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+
+public record CounselorAvailabilityResponse(
+        List<AvailabilitySlot> slots) {
+    public record AvailabilitySlot(
+            Long availabilityId,
+            LocalDate date,
+            LocalTime time,
+            boolean isBooked) {
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/dto/response/CounselorDetailResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/dto/response/CounselorDetailResponse.java
@@ -1,0 +1,23 @@
+package com.example.kbuddy_backend.livechat.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record CounselorDetailResponse(
+        String counselorId,
+        String name,
+        String intro,
+        String specialty,
+        BigDecimal ratingAvg,
+        int reviewCount,
+        int hourlyRate,
+        String profileImageUrl,
+        List<RecentReview> recentReviews) {
+    public record RecentReview(
+            Long reviewId,
+            String customerName,
+            int rating,
+            String comment,
+            String createdAt) {
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/dto/response/CounselorListResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/dto/response/CounselorListResponse.java
@@ -1,0 +1,19 @@
+package com.example.kbuddy_backend.livechat.dto.response;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public record CounselorListResponse(
+        List<CounselorSummary> content,
+        long totalElements) {
+    public record CounselorSummary(
+            String counselorId,
+            String name,
+            String intro,
+            String specialty,
+            BigDecimal ratingAvg,
+            int reviewCount,
+            int hourlyRate,
+            String profileImageUrl) {
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/entity/Booking.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/entity/Booking.java
@@ -1,0 +1,91 @@
+package com.example.kbuddy_backend.livechat.entity;
+
+import com.example.kbuddy_backend.common.entity.BaseTimeEntity;
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "booking")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Booking extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private User customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "counselor_id", nullable = false)
+    private User counselor;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "availability_id", nullable = false)
+    private CounselorAvailability availability;
+
+    @Column(nullable = false)
+    private Integer totalPrice;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private BookingStatus status;
+
+    @Builder
+    public Booking(User customer, User counselor, CounselorAvailability availability, Integer totalPrice) {
+        this.customer = customer;
+        this.counselor = counselor;
+        this.availability = availability;
+        this.totalPrice = totalPrice;
+        this.status = BookingStatus.PENDING;
+    }
+
+    public void confirmPayment() {
+        if (this.status != BookingStatus.PENDING) {
+            throw new IllegalStateException("결제 대기 상태의 예약만 결제 확인이 가능합니다");
+        }
+        this.status = BookingStatus.PAID;
+    }
+
+    public void complete() {
+        if (this.status != BookingStatus.PAID) {
+            throw new IllegalStateException("결제 완료된 예약만 완료 처리가 가능합니다");
+        }
+        this.status = BookingStatus.COMPLETED;
+    }
+
+    public void cancel() {
+        if (this.status == BookingStatus.COMPLETED || this.status == BookingStatus.REFUNDED) {
+            throw new IllegalStateException("완료되었거나 환불된 예약은 취소할 수 없습니다");
+        }
+        this.status = BookingStatus.CANCELLED;
+        this.availability.cancelBooking();
+    }
+
+    public void refund() {
+        if (this.status != BookingStatus.CANCELLED) {
+            throw new IllegalStateException("취소된 예약만 환불 처리가 가능합니다");
+        }
+        this.status = BookingStatus.REFUNDED;
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorAvailability.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorAvailability.java
@@ -1,0 +1,66 @@
+package com.example.kbuddy_backend.livechat.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Version;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Entity
+@Table(name = "counselor_availability")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CounselorAvailability {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "counselor_id", nullable = false)
+    private CounselorProfile counselor;
+
+    @Column(nullable = false)
+    private LocalDate availableDate;
+
+    @Column(nullable = false)
+    private LocalTime startTime;
+
+    @Column(nullable = false)
+    private boolean isBooked = false;
+
+    @Version
+    private Integer version;
+
+    @Builder
+    public CounselorAvailability(CounselorProfile counselor, LocalDate availableDate, LocalTime startTime) {
+        this.counselor = counselor;
+        this.availableDate = availableDate;
+        this.startTime = startTime;
+        this.isBooked = false;
+    }
+
+    public void book() {
+        if (this.isBooked) {
+            throw new IllegalStateException("이미 예약된 슬롯입니다");
+        }
+        this.isBooked = true;
+    }
+
+    public void cancelBooking() {
+        this.isBooked = false;
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorInquiry.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorInquiry.java
@@ -1,0 +1,64 @@
+package com.example.kbuddy_backend.livechat.entity;
+
+import com.example.kbuddy_backend.common.entity.BaseTimeEntity;
+import com.example.kbuddy_backend.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "counselor_inquiry")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CounselorInquiry extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "counselor_id", nullable = false)
+    private User counselor;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", nullable = false)
+    private User writer;
+
+    @Column(nullable = false, length = 200)
+    private String title;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean isSecret = false;
+
+    @Builder
+    public CounselorInquiry(User counselor, User writer, String title, String content, boolean isSecret) {
+        this.counselor = counselor;
+        this.writer = writer;
+        this.title = title;
+        this.content = content;
+        this.isSecret = isSecret;
+    }
+
+    public boolean canView(User user) {
+        if (!this.isSecret) {
+            return true;
+        }
+        return user.getId().equals(this.writer.getId()) ||
+                user.getId().equals(this.counselor.getId());
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorProfile.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorProfile.java
@@ -1,0 +1,77 @@
+package com.example.kbuddy_backend.livechat.entity;
+
+import com.example.kbuddy_backend.common.entity.BaseTimeEntity;
+import com.example.kbuddy_backend.livechat.constant.Specialty;
+import com.example.kbuddy_backend.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Entity
+@Table(name = "counselor_profile")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CounselorProfile extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String intro;
+
+    @Enumerated(EnumType.STRING)
+    @Column(length = 50)
+    private Specialty specialty;
+
+    @Column(nullable = false)
+    private Integer hourlyRate;
+
+    @Column(precision = 3, scale = 2)
+    private BigDecimal ratingAvg;
+
+    @Builder
+    public CounselorProfile(User user, String intro, Specialty specialty, Integer hourlyRate) {
+        this.user = user;
+        this.intro = intro;
+        this.specialty = specialty;
+        this.hourlyRate = hourlyRate;
+        this.ratingAvg = BigDecimal.ZERO;
+    }
+
+    public void updateProfile(String intro, Specialty specialty, Integer hourlyRate) {
+        if (intro != null) {
+            this.intro = intro;
+        }
+        if (specialty != null) {
+            this.specialty = specialty;
+        }
+        if (hourlyRate != null) {
+            this.hourlyRate = hourlyRate;
+        }
+    }
+
+    public void updateRatingAvg(BigDecimal ratingAvg) {
+        this.ratingAvg = ratingAvg;
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorReview.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/entity/CounselorReview.java
@@ -1,0 +1,75 @@
+package com.example.kbuddy_backend.livechat.entity;
+
+import com.example.kbuddy_backend.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "counselor_review")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CounselorReview {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booking_id", nullable = false, unique = true)
+    private Booking booking;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private User customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "counselor_id", nullable = false)
+    private User counselor;
+
+    @Column(nullable = false)
+    private Integer rating;
+
+    @Column(columnDefinition = "TEXT")
+    private String comment;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public CounselorReview(Booking booking, User customer, User counselor, Integer rating, String comment) {
+        validateRating(rating);
+        this.booking = booking;
+        this.customer = customer;
+        this.counselor = counselor;
+        this.rating = rating;
+        this.comment = comment;
+    }
+
+    private void validateRating(Integer rating) {
+        if (rating == null || rating < 1 || rating > 5) {
+            throw new IllegalArgumentException("평점은 1점에서 5점 사이여야 합니다");
+        }
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/entity/InquiryReply.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/entity/InquiryReply.java
@@ -1,0 +1,67 @@
+package com.example.kbuddy_backend.livechat.entity;
+
+import com.example.kbuddy_backend.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "inquiry_reply")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class InquiryReply {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "inquiry_id", nullable = false)
+    private CounselorInquiry inquiry;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+    @Builder
+    public InquiryReply(CounselorInquiry inquiry, User user, String content) {
+        validateReplyPermission(inquiry, user);
+        this.inquiry = inquiry;
+        this.user = user;
+        this.content = content;
+    }
+
+    private void validateReplyPermission(CounselorInquiry inquiry, User user) {
+        boolean isWriter = user.getId().equals(inquiry.getWriter().getId());
+        boolean isCounselor = user.getId().equals(inquiry.getCounselor().getId());
+        if (!isWriter && !isCounselor) {
+            throw new IllegalArgumentException("작성자 또는 상담사만 답변할 수 있습니다");
+        }
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/repository/BookingRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/repository/BookingRepository.java
@@ -1,0 +1,33 @@
+package com.example.kbuddy_backend.livechat.repository;
+
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface BookingRepository extends JpaRepository<Booking, Long> {
+
+    Page<Booking> findByCustomer(User customer, Pageable pageable);
+
+    Page<Booking> findByCounselor(User counselor, Pageable pageable);
+
+    Page<Booking> findByCustomerAndStatus(User customer, BookingStatus status, Pageable pageable);
+
+    Optional<Booking> findByAvailabilityId(Long availabilityId);
+
+    @Query("SELECT b FROM Booking b WHERE b.status = :status AND b.createdDate < :expireTime")
+    List<Booking> findExpiredPendingBookings(
+            @Param("status") BookingStatus status,
+            @Param("expireTime") LocalDateTime expireTime);
+
+    boolean existsByAvailabilityId(Long availabilityId);
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorAvailabilityRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorAvailabilityRepository.java
@@ -1,0 +1,36 @@
+package com.example.kbuddy_backend.livechat.repository;
+
+import com.example.kbuddy_backend.livechat.entity.CounselorAvailability;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+
+import jakarta.persistence.LockModeType;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface CounselorAvailabilityRepository extends JpaRepository<CounselorAvailability, Long> {
+
+    List<CounselorAvailability> findByCounselorAndAvailableDateBetween(
+            CounselorProfile counselor, LocalDate startDate, LocalDate endDate);
+
+    List<CounselorAvailability> findByCounselorIdAndAvailableDateBetween(
+            Long counselorId, LocalDate startDate, LocalDate endDate);
+
+    @Query("SELECT ca FROM CounselorAvailability ca WHERE ca.counselor.id = :counselorId " +
+            "AND ca.availableDate = :date AND ca.isBooked = false")
+    List<CounselorAvailability> findAvailableSlots(
+            @Param("counselorId") Long counselorId, @Param("date") LocalDate date);
+
+    @Lock(LockModeType.OPTIMISTIC)
+    @Query("SELECT ca FROM CounselorAvailability ca WHERE ca.id = :id")
+    Optional<CounselorAvailability> findByIdWithLock(@Param("id") Long id);
+
+    boolean existsByCounselorAndAvailableDateAndStartTime(
+            CounselorProfile counselor, LocalDate date, java.time.LocalTime startTime);
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorInquiryRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorInquiryRepository.java
@@ -1,0 +1,24 @@
+package com.example.kbuddy_backend.livechat.repository;
+
+import com.example.kbuddy_backend.livechat.entity.CounselorInquiry;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CounselorInquiryRepository extends JpaRepository<CounselorInquiry, Long> {
+
+    Page<CounselorInquiry> findByCounselorId(Long counselorId, Pageable pageable);
+
+    @Query("SELECT i FROM CounselorInquiry i WHERE i.counselor.id = :counselorId " +
+            "AND (i.isSecret = false OR i.writer = :user OR i.counselor = :user)")
+    Page<CounselorInquiry> findVisibleInquiries(
+            @Param("counselorId") Long counselorId,
+            @Param("user") User user,
+            Pageable pageable);
+
+    Page<CounselorInquiry> findByWriter(User writer, Pageable pageable);
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorProfileRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorProfileRepository.java
@@ -1,0 +1,28 @@
+package com.example.kbuddy_backend.livechat.repository;
+
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.constant.Specialty;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface CounselorProfileRepository extends JpaRepository<CounselorProfile, Long> {
+
+    Optional<CounselorProfile> findByUser(User user);
+
+    Optional<CounselorProfile> findByUserId(Long userId);
+
+    boolean existsByUserId(Long userId);
+
+    @Query("SELECT cp FROM CounselorProfile cp WHERE (:specialty IS NULL OR cp.specialty = :specialty)")
+    Page<CounselorProfile> findAllBySpecialty(@Param("specialty") Specialty specialty, Pageable pageable);
+
+    @Query("SELECT cp FROM CounselorProfile cp ORDER BY cp.ratingAvg DESC")
+    Page<CounselorProfile> findAllOrderByRatingDesc(Pageable pageable);
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorReviewRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/repository/CounselorReviewRepository.java
@@ -1,0 +1,33 @@
+package com.example.kbuddy_backend.livechat.repository;
+
+import com.example.kbuddy_backend.livechat.entity.CounselorReview;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+
+public interface CounselorReviewRepository extends JpaRepository<CounselorReview, Long> {
+
+    Page<CounselorReview> findByCounselor(User counselor, Pageable pageable);
+
+    Page<CounselorReview> findByCounselorId(Long counselorId, Pageable pageable);
+
+    List<CounselorReview> findTop3ByCounselorIdOrderByCreatedAtDesc(Long counselorId);
+
+    Optional<CounselorReview> findByBookingId(Long bookingId);
+
+    boolean existsByBookingId(Long bookingId);
+
+    @Query("SELECT AVG(r.rating) FROM CounselorReview r WHERE r.counselor.id = :counselorId")
+    BigDecimal calculateAverageRating(@Param("counselorId") Long counselorId);
+
+    @Query("SELECT COUNT(r) FROM CounselorReview r WHERE r.counselor.id = :counselorId")
+    long countByCounselorId(@Param("counselorId") Long counselorId);
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/repository/InquiryReplyRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/repository/InquiryReplyRepository.java
@@ -1,0 +1,14 @@
+package com.example.kbuddy_backend.livechat.repository;
+
+import com.example.kbuddy_backend.livechat.entity.InquiryReply;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface InquiryReplyRepository extends JpaRepository<InquiryReply, Long> {
+
+    List<InquiryReply> findByInquiryIdOrderByCreatedAtAsc(Long inquiryId);
+
+    long countByInquiryId(Long inquiryId);
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/service/BookingService.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/service/BookingService.java
@@ -1,0 +1,121 @@
+package com.example.kbuddy_backend.livechat.service;
+
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.dto.request.BookingReserveRequest;
+import com.example.kbuddy_backend.livechat.dto.response.BookingReserveResponse;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.livechat.entity.CounselorAvailability;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.repository.BookingRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorAvailabilityRepository;
+import com.example.kbuddy_backend.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class BookingService {
+
+    private static final int PAYMENT_TIMEOUT_MINUTES = 10;
+
+    private final BookingRepository bookingRepository;
+    private final CounselorAvailabilityRepository availabilityRepository;
+
+    @Transactional
+    public BookingReserveResponse reserve(User customer, BookingReserveRequest request) {
+        try {
+            // 낙관적 락으로 슬롯 조회
+            CounselorAvailability slot = availabilityRepository.findByIdWithLock(request.availabilityId())
+                    .orElseThrow(() -> new IllegalArgumentException("가용 시간 슬롯을 찾을 수 없습니다"));
+
+            // 이미 예약된 슬롯인지 확인
+            if (slot.isBooked()) {
+                throw new IllegalStateException("이미 예약된 시간대입니다");
+            }
+
+            // 슬롯 예약 처리
+            slot.book();
+
+            // 상담사 정보 조회
+            CounselorProfile counselorProfile = slot.getCounselor();
+            User counselor = counselorProfile.getUser();
+
+            // Booking 생성
+            Booking booking = Booking.builder()
+                    .customer(customer)
+                    .counselor(counselor)
+                    .availability(slot)
+                    .totalPrice(counselorProfile.getHourlyRate())
+                    .build();
+
+            bookingRepository.save(booking);
+
+            // 결제 만료 시간 계산
+            Instant holdExpiresAt = Instant.now().plusSeconds(PAYMENT_TIMEOUT_MINUTES * 60L);
+
+            return new BookingReserveResponse(booking.getId(), booking.getStatus().name(), holdExpiresAt);
+
+        } catch (ObjectOptimisticLockingFailureException e) {
+            throw new IllegalStateException("다른 사용자가 방금 예약한 시간대입니다. 다른 시간을 선택해주세요.");
+        }
+    }
+
+    @Transactional
+    public void confirmPayment(Long bookingId) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다"));
+
+        booking.confirmPayment();
+    }
+
+    @Transactional
+    public void completeBooking(Long bookingId) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다"));
+
+        booking.complete();
+    }
+
+    @Transactional
+    public void cancelBooking(User user, Long bookingId) {
+        Booking booking = bookingRepository.findById(bookingId)
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다"));
+
+        // 본인 예약인지 확인
+        if (!booking.getCustomer().getId().equals(user.getId())) {
+            throw new IllegalArgumentException("이 예약을 취소할 권한이 없습니다");
+        }
+
+        booking.cancel();
+    }
+
+    @Scheduled(fixedRate = 60000) // 1분마다 실행
+    @Transactional
+    public void cancelExpiredBookings() {
+        LocalDateTime expireTime = LocalDateTime.now().minusMinutes(PAYMENT_TIMEOUT_MINUTES);
+
+        List<Booking> expiredBookings = bookingRepository.findExpiredPendingBookings(
+                BookingStatus.PENDING, expireTime);
+
+        for (Booking booking : expiredBookings) {
+            try {
+                booking.cancel();
+                log.info("만료된 예약 자동 취소: {}", booking.getId());
+            } catch (Exception e) {
+                log.error("만료된 예약 취소 실패: {}", booking.getId(), e);
+            }
+        }
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorAvailabilityService.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorAvailabilityService.java
@@ -1,0 +1,61 @@
+package com.example.kbuddy_backend.livechat.service;
+
+import com.example.kbuddy_backend.livechat.entity.CounselorAvailability;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.repository.CounselorAvailabilityRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorProfileRepository;
+import com.example.kbuddy_backend.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CounselorAvailabilityService {
+
+    private final CounselorAvailabilityRepository availabilityRepository;
+    private final CounselorProfileRepository counselorProfileRepository;
+
+    @Transactional
+    public void addAvailability(User counselor, LocalDate date, LocalTime startTime) {
+        CounselorProfile profile = counselorProfileRepository.findByUserId(counselor.getId())
+                .orElseThrow(() -> new IllegalArgumentException("상담사로 등록되지 않은 사용자입니다"));
+
+        // 중복 체크
+        if (availabilityRepository.existsByCounselorAndAvailableDateAndStartTime(profile, date, startTime)) {
+            throw new IllegalStateException("해당 시간대에 이미 가용 시간이 존재합니다");
+        }
+
+        CounselorAvailability availability = CounselorAvailability.builder()
+                .counselor(profile)
+                .availableDate(date)
+                .startTime(startTime)
+                .build();
+
+        availabilityRepository.save(availability);
+    }
+
+    @Transactional
+    public void removeAvailability(User counselor, Long availabilityId) {
+        CounselorAvailability availability = availabilityRepository.findById(availabilityId)
+                .orElseThrow(() -> new IllegalArgumentException("가용 시간을 찾을 수 없습니다"));
+
+        // 본인 소유 확인
+        if (!availability.getCounselor().getUser().getId().equals(counselor.getId())) {
+            throw new IllegalArgumentException("이 가용 시간을 삭제할 권한이 없습니다");
+        }
+
+        // 이미 예약된 슬롯은 삭제 불가
+        if (availability.isBooked()) {
+            throw new IllegalStateException("예약된 슬롯은 삭제할 수 없습니다");
+        }
+
+        availabilityRepository.delete(availability);
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorInquiryService.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorInquiryService.java
@@ -1,0 +1,79 @@
+package com.example.kbuddy_backend.livechat.service;
+
+import com.example.kbuddy_backend.livechat.dto.request.CreateInquiryRequest;
+import com.example.kbuddy_backend.livechat.entity.CounselorInquiry;
+import com.example.kbuddy_backend.livechat.entity.InquiryReply;
+import com.example.kbuddy_backend.livechat.repository.CounselorInquiryRepository;
+import com.example.kbuddy_backend.livechat.repository.InquiryReplyRepository;
+import com.example.kbuddy_backend.user.entity.User;
+import com.example.kbuddy_backend.user.repository.UserRepository;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CounselorInquiryService {
+
+    private final CounselorInquiryRepository inquiryRepository;
+    private final InquiryReplyRepository replyRepository;
+    private final UserRepository userRepository;
+
+    @Transactional
+    public void createInquiry(User writer, Long counselorId, CreateInquiryRequest request) {
+        User counselor = userRepository.findById(counselorId)
+                .orElseThrow(() -> new IllegalArgumentException("상담사를 찾을 수 없습니다"));
+
+        CounselorInquiry inquiry = CounselorInquiry.builder()
+                .counselor(counselor)
+                .writer(writer)
+                .title(request.title())
+                .content(request.content())
+                .isSecret(request.isSecret())
+                .build();
+
+        inquiryRepository.save(inquiry);
+    }
+
+    public Page<CounselorInquiry> getInquiries(User user, Long counselorId, Pageable pageable) {
+        return inquiryRepository.findVisibleInquiries(counselorId, user, pageable);
+    }
+
+    public CounselorInquiry getInquiryDetail(User user, Long inquiryId) {
+        CounselorInquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new IllegalArgumentException("문의글을 찾을 수 없습니다"));
+
+        // 비밀글 권한 확인
+        if (!inquiry.canView(user)) {
+            throw new IllegalArgumentException("이 문의글을 볼 권한이 없습니다");
+        }
+
+        return inquiry;
+    }
+
+    public List<InquiryReply> getReplies(Long inquiryId) {
+        return replyRepository.findByInquiryIdOrderByCreatedAtAsc(inquiryId);
+    }
+
+    @Transactional
+    public void createReply(User user, Long inquiryId, String content) {
+        CounselorInquiry inquiry = inquiryRepository.findById(inquiryId)
+                .orElseThrow(() -> new IllegalArgumentException("문의글을 찾을 수 없습니다"));
+
+        // InquiryReply 생성자에서 권한 검증
+        InquiryReply reply = InquiryReply.builder()
+                .inquiry(inquiry)
+                .user(user)
+                .content(content)
+                .build();
+
+        replyRepository.save(reply);
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorProfileService.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorProfileService.java
@@ -1,0 +1,126 @@
+package com.example.kbuddy_backend.livechat.service;
+
+import com.example.kbuddy_backend.livechat.constant.Specialty;
+import com.example.kbuddy_backend.livechat.dto.response.CounselorAvailabilityResponse;
+import com.example.kbuddy_backend.livechat.dto.response.CounselorDetailResponse;
+import com.example.kbuddy_backend.livechat.dto.response.CounselorListResponse;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.entity.CounselorReview;
+import com.example.kbuddy_backend.livechat.repository.CounselorAvailabilityRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorProfileRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorReviewRepository;
+import com.example.kbuddy_backend.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.time.YearMonth;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CounselorProfileService {
+
+        private final CounselorProfileRepository counselorProfileRepository;
+        private final CounselorAvailabilityRepository availabilityRepository;
+        private final CounselorReviewRepository reviewRepository;
+
+        public CounselorListResponse getCounselors(Specialty specialty, String sort, Pageable pageable) {
+                Page<CounselorProfile> profiles;
+
+                if ("rating".equals(sort)) {
+                        profiles = counselorProfileRepository.findAllOrderByRatingDesc(pageable);
+                } else {
+                        profiles = counselorProfileRepository.findAllBySpecialty(specialty, pageable);
+                }
+
+                List<CounselorListResponse.CounselorSummary> content = profiles.getContent().stream()
+                                .map(this::toSummary)
+                                .toList();
+
+                return new CounselorListResponse(content, profiles.getTotalElements());
+        }
+
+        public CounselorDetailResponse getCounselor(Long counselorId) {
+                CounselorProfile profile = counselorProfileRepository.findById(counselorId)
+                                .orElseThrow(() -> new IllegalArgumentException("상담사를 찾을 수 없습니다: " + counselorId));
+
+                List<CounselorReview> recentReviews = reviewRepository
+                                .findTop3ByCounselorIdOrderByCreatedAtDesc(profile.getUser().getId());
+
+                long reviewCount = reviewRepository.countByCounselorId(profile.getUser().getId());
+
+                return new CounselorDetailResponse(
+                                profile.getId().toString(),
+                                profile.getUser().getFirstName() + " " + profile.getUser().getLastName(),
+                                profile.getIntro(),
+                                profile.getSpecialty() != null ? profile.getSpecialty().name() : null,
+                                profile.getRatingAvg(),
+                                (int) reviewCount,
+                                profile.getHourlyRate(),
+                                profile.getUser().getProfileImageUrl(),
+                                recentReviews.stream()
+                                                .map(r -> new CounselorDetailResponse.RecentReview(
+                                                                r.getId(),
+                                                                r.getCustomer().getFirstName(),
+                                                                r.getRating(),
+                                                                r.getComment(),
+                                                                r.getCreatedAt().toString()))
+                                                .toList());
+        }
+
+        public CounselorAvailabilityResponse getAvailability(Long counselorId, int year, int month) {
+                YearMonth yearMonth = YearMonth.of(year, month);
+                LocalDate startDate = yearMonth.atDay(1);
+                LocalDate endDate = yearMonth.atEndOfMonth();
+
+                var slots = availabilityRepository.findByCounselorIdAndAvailableDateBetween(
+                                counselorId, startDate, endDate);
+
+                List<CounselorAvailabilityResponse.AvailabilitySlot> slotList = slots.stream()
+                                .map(s -> new CounselorAvailabilityResponse.AvailabilitySlot(
+                                                s.getId(),
+                                                s.getAvailableDate(),
+                                                s.getStartTime(),
+                                                s.isBooked()))
+                                .toList();
+
+                return new CounselorAvailabilityResponse(slotList);
+        }
+
+        @Transactional
+        public void registerCounselor(User user, String intro, Specialty specialty, Integer hourlyRate) {
+                if (counselorProfileRepository.existsByUserId(user.getId())) {
+                        throw new IllegalStateException("이미 상담사로 등록된 사용자입니다");
+                }
+
+                CounselorProfile profile = CounselorProfile.builder()
+                                .user(user)
+                                .intro(intro)
+                                .specialty(specialty)
+                                .hourlyRate(hourlyRate)
+                                .build();
+
+                counselorProfileRepository.save(profile);
+        }
+
+        private CounselorListResponse.CounselorSummary toSummary(CounselorProfile profile) {
+                long reviewCount = reviewRepository.countByCounselorId(profile.getUser().getId());
+
+                return new CounselorListResponse.CounselorSummary(
+                                profile.getId().toString(),
+                                profile.getUser().getFirstName() + " " + profile.getUser().getLastName(),
+                                profile.getIntro(),
+                                profile.getSpecialty() != null ? profile.getSpecialty().name() : null,
+                                profile.getRatingAvg(),
+                                (int) reviewCount,
+                                profile.getHourlyRate(),
+                                profile.getUser().getProfileImageUrl());
+        }
+}

--- a/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorReviewService.java
+++ b/src/main/java/com/example/kbuddy_backend/livechat/service/CounselorReviewService.java
@@ -1,0 +1,73 @@
+package com.example.kbuddy_backend.livechat.service;
+
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.dto.request.CreateReviewRequest;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.entity.CounselorReview;
+import com.example.kbuddy_backend.livechat.repository.BookingRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorProfileRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorReviewRepository;
+import com.example.kbuddy_backend.user.entity.User;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CounselorReviewService {
+
+    private final CounselorReviewRepository reviewRepository;
+    private final BookingRepository bookingRepository;
+    private final CounselorProfileRepository counselorProfileRepository;
+
+    @Transactional
+    public void createReview(User customer, CreateReviewRequest request) {
+        Booking booking = bookingRepository.findById(request.bookingId())
+                .orElseThrow(() -> new IllegalArgumentException("예약을 찾을 수 없습니다"));
+
+        // 본인 예약인지 확인
+        if (!booking.getCustomer().getId().equals(customer.getId())) {
+            throw new IllegalArgumentException("이 예약에 대한 리뷰 작성 권한이 없습니다");
+        }
+
+        // 상담 완료 상태인지 확인
+        if (booking.getStatus() != BookingStatus.COMPLETED) {
+            throw new IllegalStateException("완료된 예약만 리뷰를 작성할 수 있습니다");
+        }
+
+        // 이미 리뷰가 있는지 확인
+        if (reviewRepository.existsByBookingId(booking.getId())) {
+            throw new IllegalStateException("이미 이 예약에 대한 리뷰가 존재합니다");
+        }
+
+        CounselorReview review = CounselorReview.builder()
+                .booking(booking)
+                .customer(customer)
+                .counselor(booking.getCounselor())
+                .rating(request.rating())
+                .comment(request.comment())
+                .build();
+
+        reviewRepository.save(review);
+
+        // 상담사 평균 평점 업데이트
+        updateCounselorRating(booking.getCounselor().getId());
+    }
+
+    private void updateCounselorRating(Long counselorUserId) {
+        CounselorProfile profile = counselorProfileRepository.findByUserId(counselorUserId)
+                .orElseThrow(() -> new IllegalArgumentException("상담사 프로필을 찾을 수 없습니다"));
+
+        BigDecimal avgRating = reviewRepository.calculateAverageRating(counselorUserId);
+
+        if (avgRating != null) {
+            profile.updateRatingAvg(avgRating);
+        }
+    }
+}

--- a/src/test/java/com/example/kbuddy_backend/fixtures/LiveChatFixtures.java
+++ b/src/test/java/com/example/kbuddy_backend/fixtures/LiveChatFixtures.java
@@ -1,0 +1,102 @@
+package com.example.kbuddy_backend.fixtures;
+
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.constant.Specialty;
+import com.example.kbuddy_backend.livechat.dto.request.BookingReserveRequest;
+import com.example.kbuddy_backend.livechat.dto.request.CreateInquiryRequest;
+import com.example.kbuddy_backend.livechat.dto.request.CreateReviewRequest;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.livechat.entity.CounselorAvailability;
+import com.example.kbuddy_backend.livechat.entity.CounselorInquiry;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.entity.CounselorReview;
+import com.example.kbuddy_backend.user.entity.User;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public class LiveChatFixtures {
+
+    // Counselor Profile
+    public static CounselorProfile createCounselorProfile(User user) {
+        return CounselorProfile.builder()
+                .user(user)
+                .intro("안녕하세요, 전문 상담사입니다.")
+                .specialty(Specialty.UNIVERSITY)
+                .hourlyRate(50000)
+                .build();
+    }
+
+    // Counselor Availability
+    public static CounselorAvailability createAvailability(CounselorProfile profile) {
+        return CounselorAvailability.builder()
+                .counselor(profile)
+                .availableDate(LocalDate.now().plusDays(1))
+                .startTime(LocalTime.of(14, 0))
+                .build();
+    }
+
+    public static CounselorAvailability createAvailability(CounselorProfile profile, LocalDate date, LocalTime time) {
+        return CounselorAvailability.builder()
+                .counselor(profile)
+                .availableDate(date)
+                .startTime(time)
+                .build();
+    }
+
+    // Booking
+    public static Booking createBooking(User customer, User counselor, CounselorAvailability availability) {
+        return Booking.builder()
+                .customer(customer)
+                .counselor(counselor)
+                .availability(availability)
+                .totalPrice(50000)
+                .build();
+    }
+
+    // Counselor Review
+    public static CounselorReview createReview(Booking booking, User customer, User counselor) {
+        return CounselorReview.builder()
+                .booking(booking)
+                .customer(customer)
+                .counselor(counselor)
+                .rating(5)
+                .comment("정말 좋은 상담이었습니다!")
+                .build();
+    }
+
+    // Counselor Inquiry
+    public static CounselorInquiry createInquiry(User counselor, User writer) {
+        return CounselorInquiry.builder()
+                .counselor(counselor)
+                .writer(writer)
+                .title("상담 문의드립니다")
+                .content("상담 가능 시간이 어떻게 되나요?")
+                .isSecret(false)
+                .build();
+    }
+
+    public static CounselorInquiry createSecretInquiry(User counselor, User writer) {
+        return CounselorInquiry.builder()
+                .counselor(counselor)
+                .writer(writer)
+                .title("비밀 문의")
+                .content("비밀 내용입니다.")
+                .isSecret(true)
+                .build();
+    }
+
+    // Request DTOs
+    public static BookingReserveRequest createBookingReserveRequest(Long availabilityId) {
+        return new BookingReserveRequest("1", availabilityId);
+    }
+
+    public static CreateReviewRequest createReviewRequest(Long bookingId) {
+        return new CreateReviewRequest(bookingId, 5, "훌륭한 상담이었습니다!");
+    }
+
+    public static CreateInquiryRequest createInquiryRequest() {
+        return new CreateInquiryRequest("상담 문의", "상담 가능 시간이 언제인가요?", false);
+    }
+}

--- a/src/test/java/com/example/kbuddy_backend/livechat/controller/BookingControllerTest.java
+++ b/src/test/java/com/example/kbuddy_backend/livechat/controller/BookingControllerTest.java
@@ -1,0 +1,72 @@
+package com.example.kbuddy_backend.livechat.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.kbuddy_backend.common.WebMVCTest;
+import com.example.kbuddy_backend.fixtures.LiveChatFixtures;
+import com.example.kbuddy_backend.fixtures.UserFixtures;
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.dto.request.BookingReserveRequest;
+import com.example.kbuddy_backend.livechat.dto.response.BookingReserveResponse;
+import com.example.kbuddy_backend.livechat.service.BookingService;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.time.Instant;
+import java.util.Optional;
+
+@WithMockUser(username = "123", roles = "USER")
+public class BookingControllerTest extends WebMVCTest {
+
+    @MockBean
+    private BookingService bookingService;
+
+    @DisplayName("예약 선점 API 테스트 - 정상")
+    @Test
+    public void testReserveBooking_Success() throws Exception {
+        // given
+        User user = UserFixtures.createUser();
+        BookingReserveRequest request = LiveChatFixtures.createBookingReserveRequest(1L);
+        BookingReserveResponse response = new BookingReserveResponse(
+                1L, BookingStatus.PENDING.name(), Instant.now().plusSeconds(600));
+
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(bookingService.reserve(any(User.class), any(BookingReserveRequest.class)))
+                .willReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/kbuddy/v1/booking/reserve")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andDo(print());
+    }
+
+    @DisplayName("예약 선점 API 테스트 - 이미 예약된 슬롯")
+    @Test
+    public void testReserveBooking_AlreadyBooked() throws Exception {
+        // given
+        User user = UserFixtures.createUser();
+        BookingReserveRequest request = LiveChatFixtures.createBookingReserveRequest(1L);
+
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        given(bookingService.reserve(any(User.class), any(BookingReserveRequest.class)))
+                .willThrow(new IllegalStateException("이미 예약된 시간대입니다"));
+
+        // when & then
+        mockMvc.perform(post("/kbuddy/v1/booking/reserve")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().is5xxServerError())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/example/kbuddy_backend/livechat/controller/CounselorReviewControllerTest.java
+++ b/src/test/java/com/example/kbuddy_backend/livechat/controller/CounselorReviewControllerTest.java
@@ -1,0 +1,93 @@
+package com.example.kbuddy_backend.livechat.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.example.kbuddy_backend.common.WebMVCTest;
+import com.example.kbuddy_backend.fixtures.LiveChatFixtures;
+import com.example.kbuddy_backend.fixtures.UserFixtures;
+import com.example.kbuddy_backend.livechat.dto.request.CreateInquiryRequest;
+import com.example.kbuddy_backend.livechat.dto.request.CreateReviewRequest;
+import com.example.kbuddy_backend.livechat.service.CounselorInquiryService;
+import com.example.kbuddy_backend.livechat.service.CounselorReviewService;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+
+import java.util.Optional;
+
+@WithMockUser(username = "123", roles = "USER")
+public class CounselorReviewControllerTest extends WebMVCTest {
+
+    @MockBean
+    private CounselorReviewService counselorReviewService;
+
+    @MockBean
+    private CounselorInquiryService counselorInquiryService;
+
+    @DisplayName("리뷰 작성 API 테스트 - 정상")
+    @Test
+    public void testCreateReview_Success() throws Exception {
+        // given
+        User user = UserFixtures.createUser();
+        CreateReviewRequest request = LiveChatFixtures.createReviewRequest(1L);
+
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        doNothing().when(counselorReviewService).createReview(any(User.class), any(CreateReviewRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/kbuddy/v1/review")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+
+    @DisplayName("리뷰 작성 API 테스트 - 완료되지 않은 예약")
+    @Test
+    public void testCreateReview_NotCompleted() throws Exception {
+        // given
+        User user = UserFixtures.createUser();
+        CreateReviewRequest request = LiveChatFixtures.createReviewRequest(1L);
+
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        doThrow(new IllegalStateException("완료된 예약만 리뷰를 작성할 수 있습니다"))
+                .when(counselorReviewService).createReview(any(User.class), any(CreateReviewRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/kbuddy/v1/review")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().is5xxServerError())
+                .andDo(print());
+    }
+
+    @DisplayName("문의글 작성 API 테스트 - 정상")
+    @Test
+    public void testCreateInquiry_Success() throws Exception {
+        // given
+        User user = UserFixtures.createUser();
+        CreateInquiryRequest request = LiveChatFixtures.createInquiryRequest();
+
+        given(userRepository.findById(any())).willReturn(Optional.of(user));
+        doNothing().when(counselorInquiryService).createInquiry(any(User.class), eq(1L),
+                any(CreateInquiryRequest.class));
+
+        // when & then
+        mockMvc.perform(post("/kbuddy/v1/counselor/1/inquiry")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNoContent())
+                .andDo(print());
+    }
+}

--- a/src/test/java/com/example/kbuddy_backend/livechat/service/BookingServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/livechat/service/BookingServiceTest.java
@@ -1,0 +1,150 @@
+package com.example.kbuddy_backend.livechat.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+import com.example.kbuddy_backend.common.IntegrationTest;
+import com.example.kbuddy_backend.common.config.DataInitializer;
+import com.example.kbuddy_backend.fixtures.LiveChatFixtures;
+import com.example.kbuddy_backend.fixtures.UserFixtures;
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.dto.request.BookingReserveRequest;
+import com.example.kbuddy_backend.livechat.dto.response.BookingReserveResponse;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.livechat.entity.CounselorAvailability;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.repository.BookingRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorAvailabilityRepository;
+import com.example.kbuddy_backend.user.entity.User;
+import com.example.kbuddy_backend.user.repository.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+public class BookingServiceTest extends IntegrationTest {
+
+    @Autowired
+    private BookingService bookingService;
+
+    @MockBean
+    private BookingRepository bookingRepository;
+
+    @MockBean
+    private CounselorAvailabilityRepository availabilityRepository;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private DataInitializer dataInitializer;
+
+    private User customer;
+    private User counselor;
+    private CounselorProfile counselorProfile;
+    private CounselorAvailability availability;
+
+    @BeforeEach
+    void setUp() {
+        customer = UserFixtures.createUser();
+        counselor = UserFixtures.createUser();
+        counselorProfile = LiveChatFixtures.createCounselorProfile(counselor);
+        availability = LiveChatFixtures.createAvailability(counselorProfile);
+    }
+
+    @DisplayName("예약 선점 테스트 - 정상적으로 예약 생성")
+    @Test
+    public void testReserve_Success() {
+        // given
+        BookingReserveRequest request = LiveChatFixtures.createBookingReserveRequest(1L);
+
+        given(availabilityRepository.findByIdWithLock(1L))
+                .willReturn(Optional.of(availability));
+        given(bookingRepository.save(any(Booking.class)))
+                .willAnswer(invocation -> invocation.getArgument(0));
+
+        // when
+        BookingReserveResponse response = bookingService.reserve(customer, request);
+
+        // then
+        assertNotNull(response);
+        assertEquals(BookingStatus.PENDING.name(), response.status());
+        assertNotNull(response.holdExpiresAt());
+        assertTrue(availability.isBooked());
+        verify(bookingRepository, times(1)).save(any(Booking.class));
+    }
+
+    @DisplayName("예약 선점 테스트 - 이미 예약된 슬롯일 때 예외 발생")
+    @Test
+    public void testReserve_AlreadyBooked() {
+        // given
+        BookingReserveRequest request = LiveChatFixtures.createBookingReserveRequest(1L);
+        availability.book(); // 이미 예약 처리
+
+        given(availabilityRepository.findByIdWithLock(1L))
+                .willReturn(Optional.of(availability));
+
+        // when & then
+        assertThrows(IllegalStateException.class, () -> {
+            bookingService.reserve(customer, request);
+        });
+
+        verify(bookingRepository, never()).save(any(Booking.class));
+    }
+
+    @DisplayName("예약 선점 테스트 - 존재하지 않는 슬롯일 때 예외 발생")
+    @Test
+    public void testReserve_SlotNotFound() {
+        // given
+        BookingReserveRequest request = LiveChatFixtures.createBookingReserveRequest(999L);
+
+        given(availabilityRepository.findByIdWithLock(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            bookingService.reserve(customer, request);
+        });
+
+        verify(bookingRepository, never()).save(any(Booking.class));
+    }
+
+    @DisplayName("결제 확인 테스트 - PENDING에서 PAID로 상태 변경")
+    @Test
+    public void testConfirmPayment_Success() {
+        // given
+        Booking booking = LiveChatFixtures.createBooking(customer, counselor, availability);
+
+        given(bookingRepository.findById(1L))
+                .willReturn(Optional.of(booking));
+
+        // when
+        bookingService.confirmPayment(1L);
+
+        // then
+        assertEquals(BookingStatus.PAID, booking.getStatus());
+    }
+
+    @DisplayName("상담 완료 테스트 - PAID에서 COMPLETED로 상태 변경")
+    @Test
+    public void testCompleteBooking_Success() {
+        // given
+        Booking booking = LiveChatFixtures.createBooking(customer, counselor, availability);
+        booking.confirmPayment(); // PENDING -> PAID
+
+        given(bookingRepository.findById(1L))
+                .willReturn(Optional.of(booking));
+
+        // when
+        bookingService.completeBooking(1L);
+
+        // then
+        assertEquals(BookingStatus.COMPLETED, booking.getStatus());
+    }
+}

--- a/src/test/java/com/example/kbuddy_backend/livechat/service/CounselorReviewServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/livechat/service/CounselorReviewServiceTest.java
@@ -1,0 +1,77 @@
+package com.example.kbuddy_backend.livechat.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+
+import com.example.kbuddy_backend.common.IntegrationTest;
+import com.example.kbuddy_backend.common.config.DataInitializer;
+import com.example.kbuddy_backend.fixtures.LiveChatFixtures;
+import com.example.kbuddy_backend.fixtures.UserFixtures;
+import com.example.kbuddy_backend.livechat.dto.request.CreateReviewRequest;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.livechat.entity.CounselorAvailability;
+import com.example.kbuddy_backend.livechat.entity.CounselorProfile;
+import com.example.kbuddy_backend.livechat.repository.BookingRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorProfileRepository;
+import com.example.kbuddy_backend.livechat.repository.CounselorReviewRepository;
+import com.example.kbuddy_backend.user.entity.User;
+import com.example.kbuddy_backend.user.repository.UserRepository;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import java.util.Optional;
+
+public class CounselorReviewServiceTest extends IntegrationTest {
+
+    @Autowired
+    private CounselorReviewService counselorReviewService;
+
+    @MockBean
+    private CounselorReviewRepository reviewRepository;
+
+    @MockBean
+    private BookingRepository bookingRepository;
+
+    @MockBean
+    private CounselorProfileRepository counselorProfileRepository;
+
+    @MockBean
+    private UserRepository userRepository;
+
+    @MockBean
+    private DataInitializer dataInitializer;
+
+    private User customer;
+    private User counselor;
+    private CounselorProfile counselorProfile;
+    private CounselorAvailability availability;
+    private Booking booking;
+
+    @BeforeEach
+    void setUp() {
+        customer = UserFixtures.createUser();
+        counselor = UserFixtures.createUser();
+        counselorProfile = LiveChatFixtures.createCounselorProfile(counselor);
+        availability = LiveChatFixtures.createAvailability(counselorProfile);
+        booking = LiveChatFixtures.createBooking(customer, counselor, availability);
+    }
+
+    @DisplayName("예약 존재하지 않을 때 리뷰 작성 시 예외 발생")
+    @Test
+    public void testCreateReview_BookingNotFound() {
+        // given
+        CreateReviewRequest request = LiveChatFixtures.createReviewRequest(999L);
+
+        given(bookingRepository.findById(999L))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThrows(IllegalArgumentException.class, () -> {
+            counselorReviewService.createReview(customer, request);
+        });
+    }
+}


### PR DESCRIPTION
## Description (요약)


## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)
- 예약 동시성 제어: 
CounselorAvailability 에 @Version 낙관적 락 적용으로 더블 부킹 방지
- 예약 자동 취소: 
BookingService 에 @Scheduled 스케줄러로 10분 내 미결제 예약 자동 취소
- 예약 상태: 
Booking 엔티티에 상태 전이 메서드 (PENDING → PAID → COMPLETED / CANCELLED → REFUNDED)
- 비밀글 권한 제어: CounselorInquiryRepository.findVisibleInquiries() JPQL로 작성자/상담사만 조회 가능
- 평점 자동 계산: 리뷰 작성 시 상담사의 평균 평점 자동 업데이트

## Screenshots (optional)


## Etc (비고)