### PR TITLE
[FEAT] 상담 결제 기능

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/payment/config/BankTransferPaymentProperties.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/config/BankTransferPaymentProperties.java
@@ -1,0 +1,20 @@
+package com.example.kbuddy_backend.payment.config;
+
+import java.math.BigDecimal;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "payment.bank-transfer")
+public class BankTransferPaymentProperties {
+
+    private String bankName = "";
+    private String accountNumber = "";
+    private String accountHolder = "KBuddy";
+    private int depositTimeoutHours = 24;
+    private BigDecimal platformFeeRate = new BigDecimal("15.00");
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/constant/PaymentMethod.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/constant/PaymentMethod.java
@@ -1,0 +1,12 @@
+package com.example.kbuddy_backend.payment.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentMethod {
+    BANK_TRANSFER("무통장 입금");
+
+    private final String description;
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/constant/PaymentStatus.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/constant/PaymentStatus.java
@@ -1,0 +1,18 @@
+package com.example.kbuddy_backend.payment.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum PaymentStatus {
+    AWAITING_DEPOSIT("입금 대기"),
+    DEPOSIT_REPORTED("입금 완료 신고"),
+    PAID("입금 확인 완료"),
+    EXPIRED("입금 기한 만료"),
+    CANCELLED("결제 취소"),
+    REFUND_PENDING("환불 대기"),
+    REFUNDED("환불 완료");
+
+    private final String description;
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/controller/AdminPaymentController.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/controller/AdminPaymentController.java
@@ -1,0 +1,86 @@
+package com.example.kbuddy_backend.payment.controller;
+
+import com.example.kbuddy_backend.common.exception.UnauthorizedException;
+import com.example.kbuddy_backend.payment.constant.PaymentStatus;
+import com.example.kbuddy_backend.payment.dto.request.PaymentCancelRequest;
+import com.example.kbuddy_backend.payment.dto.request.PaymentConfirmRequest;
+import com.example.kbuddy_backend.payment.dto.response.PaymentResponse;
+import com.example.kbuddy_backend.payment.service.PaymentService;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kbuddy/v1/admin/payments")
+@Tag(name = "Admin Payment API", description = "관리자 결제 API")
+public class AdminPaymentController {
+
+    private static final String ADMIN_ROLE = "ROLE_ADMIN";
+
+    private final PaymentService paymentService;
+
+    @GetMapping
+    @Operation(summary = "관리자 결제 목록 조회", description = "결제 상태로 필터링해 결제 목록을 조회합니다.")
+    public ResponseEntity<Page<PaymentResponse>> getPayments(
+            @RequestParam(required = false) PaymentStatus status,
+            @PageableDefault(size = 50, sort = "id", direction = Sort.Direction.DESC) Pageable pageable) {
+        validateAdmin();
+        return ResponseEntity.ok(paymentService.getPayments(status, pageable));
+    }
+
+    @GetMapping("/{paymentId}")
+    @Operation(summary = "관리자 결제 상세 조회", description = "결제 상세 정보를 조회합니다.")
+    public ResponseEntity<PaymentResponse> getPayment(@PathVariable Long paymentId) {
+        validateAdmin();
+        return ResponseEntity.ok(paymentService.getPaymentForAdmin(paymentId));
+    }
+
+    @PatchMapping("/{paymentId}/confirm-deposit")
+    @Operation(summary = "입금 확인", description = "관리자가 무통장 입금을 확인하고 예약을 결제 완료 상태로 전환합니다.")
+    public ResponseEntity<PaymentResponse> confirmDeposit(
+            @PathVariable Long paymentId,
+            @RequestBody(required = false) PaymentConfirmRequest request) {
+        validateAdmin();
+        return ResponseEntity.ok(paymentService.confirmDeposit(paymentId, request));
+    }
+
+    @PatchMapping("/{paymentId}/cancel")
+    @Operation(summary = "결제 취소", description = "관리자가 입금 대기 결제를 취소합니다.")
+    public ResponseEntity<PaymentResponse> cancelPayment(
+            @PathVariable Long paymentId,
+            @Valid @RequestBody PaymentCancelRequest request) {
+        validateAdmin();
+        return ResponseEntity.ok(paymentService.cancelPayment(paymentId, request));
+    }
+
+    private void validateAdmin() {
+        boolean hasAdminRole = SecurityContextHolder.getContextHolderStrategy().getContext()
+                .getAuthentication()
+                .getAuthorities()
+                .stream()
+                .anyMatch(authority -> ADMIN_ROLE.equals(authority.getAuthority()));
+
+        if (!hasAdminRole) {
+            throw new UnauthorizedException("관리자 권한이 없습니다");
+        }
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/controller/PaymentController.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/controller/PaymentController.java
@@ -1,0 +1,79 @@
+package com.example.kbuddy_backend.payment.controller;
+
+import com.example.kbuddy_backend.common.config.CurrentUser;
+import com.example.kbuddy_backend.payment.dto.request.BankTransferPaymentCreateRequest;
+import com.example.kbuddy_backend.payment.dto.request.DepositReportRequest;
+import com.example.kbuddy_backend.payment.dto.response.PaymentResponse;
+import com.example.kbuddy_backend.payment.service.PaymentService;
+import com.example.kbuddy_backend.user.entity.User;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+import jakarta.validation.Valid;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/kbuddy/v1/payments")
+@Tag(name = "Payment API", description = "결제 API")
+public class PaymentController {
+
+    private final PaymentService paymentService;
+
+    @PostMapping("/bank-transfer")
+    @Operation(summary = "무통장 입금 결제 생성", description = "예약 ID로 무통장 입금 결제를 생성하고 입금 안내 정보를 반환합니다.")
+    public ResponseEntity<PaymentResponse> createBankTransferPayment(
+            @Valid @RequestBody BankTransferPaymentCreateRequest request,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        return ResponseEntity.ok(paymentService.createBankTransferPayment(user, request));
+    }
+
+    @GetMapping
+    @Operation(summary = "내 결제 목록 조회", description = "로그인한 사용자의 결제 목록을 조회합니다.")
+    public ResponseEntity<Page<PaymentResponse>> getMyPayments(
+            @PageableDefault(size = 20, sort = "id", direction = Sort.Direction.DESC) Pageable pageable,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        return ResponseEntity.ok(paymentService.getMyPayments(user, pageable));
+    }
+
+    @GetMapping("/{paymentId}")
+    @Operation(summary = "결제 상세 조회", description = "로그인한 사용자의 결제 상세 정보를 조회합니다.")
+    public ResponseEntity<PaymentResponse> getPayment(
+            @PathVariable Long paymentId,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        return ResponseEntity.ok(paymentService.getPayment(user, paymentId));
+    }
+
+    @GetMapping("/bookings/{bookingId}")
+    @Operation(summary = "예약 결제 조회", description = "예약 ID로 결제 정보를 조회합니다.")
+    public ResponseEntity<PaymentResponse> getPaymentByBooking(
+            @PathVariable Long bookingId,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        return ResponseEntity.ok(paymentService.getPaymentByBooking(user, bookingId));
+    }
+
+    @PatchMapping("/{paymentId}/deposit-report")
+    @Operation(summary = "입금 완료 신고", description = "내담자가 입금자명과 메모를 제출해 입금 완료를 알립니다.")
+    public ResponseEntity<PaymentResponse> reportDeposit(
+            @PathVariable Long paymentId,
+            @Valid @RequestBody DepositReportRequest request,
+            @Parameter(hidden = true) @CurrentUser User user) {
+        return ResponseEntity.ok(paymentService.reportDeposit(user, paymentId, request));
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/dto/request/BankTransferPaymentCreateRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/dto/request/BankTransferPaymentCreateRequest.java
@@ -1,0 +1,9 @@
+package com.example.kbuddy_backend.payment.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record BankTransferPaymentCreateRequest(
+        @NotNull Long bookingId,
+        String depositorName
+) {
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/dto/request/DepositReportRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/dto/request/DepositReportRequest.java
@@ -1,0 +1,9 @@
+package com.example.kbuddy_backend.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record DepositReportRequest(
+        @NotBlank String depositorName,
+        String memo
+) {
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/dto/request/PaymentCancelRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/dto/request/PaymentCancelRequest.java
@@ -1,0 +1,8 @@
+package com.example.kbuddy_backend.payment.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record PaymentCancelRequest(
+        @NotBlank String reason
+) {
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/dto/request/PaymentConfirmRequest.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/dto/request/PaymentConfirmRequest.java
@@ -1,0 +1,7 @@
+package com.example.kbuddy_backend.payment.dto.request;
+
+public record PaymentConfirmRequest(
+        Integer confirmedAmount,
+        String adminMemo
+) {
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/dto/response/PaymentResponse.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/dto/response/PaymentResponse.java
@@ -1,0 +1,65 @@
+package com.example.kbuddy_backend.payment.dto.response;
+
+import com.example.kbuddy_backend.payment.constant.PaymentMethod;
+import com.example.kbuddy_backend.payment.constant.PaymentStatus;
+import com.example.kbuddy_backend.payment.entity.Payment;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record PaymentResponse(
+        Long paymentId,
+        Long bookingId,
+        Long customerId,
+        Long counselorId,
+        PaymentMethod method,
+        PaymentStatus status,
+        Integer totalAmount,
+        BigDecimal platformFeeRate,
+        Integer platformFeeAmount,
+        Integer counselorSettlementAmount,
+        String bankName,
+        String accountNumber,
+        String accountHolder,
+        String depositorName,
+        LocalDateTime depositDueAt,
+        LocalDateTime depositReportedAt,
+        Integer confirmedAmount,
+        LocalDateTime paidAt,
+        LocalDateTime cancelledAt,
+        String cancelReason,
+        String customerMemo,
+        String adminMemo,
+        LocalDateTime createdDate,
+        LocalDateTime lastModifiedDate
+) {
+
+    public static PaymentResponse from(Payment payment) {
+        return new PaymentResponse(
+                payment.getId(),
+                payment.getBooking().getId(),
+                payment.getCustomer().getId(),
+                payment.getCounselor().getId(),
+                payment.getMethod(),
+                payment.getStatus(),
+                payment.getTotalAmount(),
+                payment.getPlatformFeeRate(),
+                payment.getPlatformFeeAmount(),
+                payment.getCounselorSettlementAmount(),
+                payment.getBankName(),
+                payment.getAccountNumber(),
+                payment.getAccountHolder(),
+                payment.getDepositorName(),
+                payment.getDepositDueAt(),
+                payment.getDepositReportedAt(),
+                payment.getConfirmedAmount(),
+                payment.getPaidAt(),
+                payment.getCancelledAt(),
+                payment.getCancelReason(),
+                payment.getCustomerMemo(),
+                payment.getAdminMemo(),
+                payment.getCreatedDate(),
+                payment.getLastModifiedDate()
+        );
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/entity/Payment.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/entity/Payment.java
@@ -1,0 +1,171 @@
+package com.example.kbuddy_backend.payment.entity;
+
+import com.example.kbuddy_backend.common.entity.BaseTimeEntity;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.payment.constant.PaymentMethod;
+import com.example.kbuddy_backend.payment.constant.PaymentStatus;
+import com.example.kbuddy_backend.user.entity.User;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.LocalDateTime;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "payment")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Payment extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "booking_id", nullable = false, unique = true)
+    private Booking booking;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "customer_id", nullable = false)
+    private User customer;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "counselor_id", nullable = false)
+    private User counselor;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentMethod method;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 30)
+    private PaymentStatus status;
+
+    @Column(nullable = false)
+    private Integer totalAmount;
+
+    @Column(nullable = false, precision = 5, scale = 2)
+    private BigDecimal platformFeeRate;
+
+    @Column(nullable = false)
+    private Integer platformFeeAmount;
+
+    @Column(nullable = false)
+    private Integer counselorSettlementAmount;
+
+    @Column(nullable = false)
+    private String bankName;
+
+    @Column(nullable = false)
+    private String accountNumber;
+
+    @Column(nullable = false)
+    private String accountHolder;
+
+    @Column(nullable = false)
+    private LocalDateTime depositDueAt;
+
+    private String depositorName;
+
+    private LocalDateTime depositReportedAt;
+
+    private Integer confirmedAmount;
+
+    private LocalDateTime paidAt;
+
+    private LocalDateTime cancelledAt;
+
+    @Column(columnDefinition = "TEXT")
+    private String cancelReason;
+
+    @Column(columnDefinition = "TEXT")
+    private String customerMemo;
+
+    @Column(columnDefinition = "TEXT")
+    private String adminMemo;
+
+    @Builder
+    public Payment(Booking booking, User customer, User counselor, Integer totalAmount,
+                   BigDecimal platformFeeRate, String bankName, String accountNumber,
+                   String accountHolder, LocalDateTime depositDueAt, String depositorName) {
+        this.booking = booking;
+        this.customer = customer;
+        this.counselor = counselor;
+        this.method = PaymentMethod.BANK_TRANSFER;
+        this.status = PaymentStatus.AWAITING_DEPOSIT;
+        this.totalAmount = totalAmount;
+        this.platformFeeRate = platformFeeRate;
+        this.platformFeeAmount = calculatePlatformFee(totalAmount, platformFeeRate);
+        this.counselorSettlementAmount = totalAmount - this.platformFeeAmount;
+        this.bankName = bankName;
+        this.accountNumber = accountNumber;
+        this.accountHolder = accountHolder;
+        this.depositDueAt = depositDueAt;
+        this.depositorName = depositorName;
+    }
+
+    public void reportDeposit(String depositorName, String customerMemo) {
+        if (this.status != PaymentStatus.AWAITING_DEPOSIT && this.status != PaymentStatus.DEPOSIT_REPORTED) {
+            throw new IllegalArgumentException("입금 대기 상태의 결제만 입금 완료 신고가 가능합니다");
+        }
+        this.status = PaymentStatus.DEPOSIT_REPORTED;
+        this.depositorName = depositorName;
+        this.customerMemo = customerMemo;
+        this.depositReportedAt = LocalDateTime.now();
+    }
+
+    public void confirmDeposit(Integer confirmedAmount, String adminMemo) {
+        if (this.status != PaymentStatus.AWAITING_DEPOSIT && this.status != PaymentStatus.DEPOSIT_REPORTED) {
+            throw new IllegalArgumentException("입금 대기 또는 입금 완료 신고 상태의 결제만 확인할 수 있습니다");
+        }
+        int amountToConfirm = confirmedAmount == null ? this.totalAmount : confirmedAmount;
+        if (amountToConfirm != this.totalAmount) {
+            throw new IllegalArgumentException("입금 확인 금액이 결제 금액과 일치하지 않습니다");
+        }
+        this.status = PaymentStatus.PAID;
+        this.confirmedAmount = amountToConfirm;
+        this.adminMemo = adminMemo;
+        this.paidAt = LocalDateTime.now();
+    }
+
+    public void cancel(String reason) {
+        if (this.status == PaymentStatus.PAID || this.status == PaymentStatus.REFUNDED) {
+            throw new IllegalArgumentException("입금 확인 또는 환불 완료된 결제는 취소할 수 없습니다");
+        }
+        this.status = PaymentStatus.CANCELLED;
+        this.cancelReason = reason;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    public void expire() {
+        if (this.status != PaymentStatus.AWAITING_DEPOSIT) {
+            throw new IllegalArgumentException("입금 대기 상태의 결제만 만료 처리할 수 있습니다");
+        }
+        this.status = PaymentStatus.EXPIRED;
+        this.cancelledAt = LocalDateTime.now();
+    }
+
+    private int calculatePlatformFee(Integer totalAmount, BigDecimal platformFeeRate) {
+        return BigDecimal.valueOf(totalAmount)
+                .multiply(platformFeeRate)
+                .divide(BigDecimal.valueOf(100), 0, RoundingMode.HALF_UP)
+                .intValue();
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/repository/PaymentRepository.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/repository/PaymentRepository.java
@@ -1,0 +1,26 @@
+package com.example.kbuddy_backend.payment.repository;
+
+import com.example.kbuddy_backend.payment.constant.PaymentStatus;
+import com.example.kbuddy_backend.payment.entity.Payment;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    Optional<Payment> findByBookingId(Long bookingId);
+
+    Optional<Payment> findByIdAndCustomer(Long id, User customer);
+
+    Page<Payment> findByCustomer(User customer, Pageable pageable);
+
+    Page<Payment> findByStatus(PaymentStatus status, Pageable pageable);
+
+    List<Payment> findByStatusAndDepositDueAtBefore(PaymentStatus status, LocalDateTime depositDueAt);
+}

--- a/src/main/java/com/example/kbuddy_backend/payment/service/PaymentService.java
+++ b/src/main/java/com/example/kbuddy_backend/payment/service/PaymentService.java
@@ -1,0 +1,161 @@
+package com.example.kbuddy_backend.payment.service;
+
+import com.example.kbuddy_backend.common.exception.BadRequestException;
+import com.example.kbuddy_backend.common.exception.NotFoundException;
+import com.example.kbuddy_backend.common.exception.UnauthorizedException;
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.livechat.repository.BookingRepository;
+import com.example.kbuddy_backend.payment.config.BankTransferPaymentProperties;
+import com.example.kbuddy_backend.payment.constant.PaymentStatus;
+import com.example.kbuddy_backend.payment.dto.request.BankTransferPaymentCreateRequest;
+import com.example.kbuddy_backend.payment.dto.request.DepositReportRequest;
+import com.example.kbuddy_backend.payment.dto.request.PaymentCancelRequest;
+import com.example.kbuddy_backend.payment.dto.request.PaymentConfirmRequest;
+import com.example.kbuddy_backend.payment.dto.response.PaymentResponse;
+import com.example.kbuddy_backend.payment.entity.Payment;
+import com.example.kbuddy_backend.payment.repository.PaymentRepository;
+import com.example.kbuddy_backend.user.entity.User;
+
+import java.time.LocalDateTime;
+
+import lombok.RequiredArgsConstructor;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentService {
+
+    private final PaymentRepository paymentRepository;
+    private final BookingRepository bookingRepository;
+    private final BankTransferPaymentProperties bankTransferPaymentProperties;
+
+    @Transactional
+    public PaymentResponse createBankTransferPayment(User customer, BankTransferPaymentCreateRequest request) {
+        Booking booking = bookingRepository.findById(request.bookingId())
+                .orElseThrow(() -> new NotFoundException("예약을 찾을 수 없습니다"));
+
+        validateBookingCustomer(customer, booking);
+
+        return paymentRepository.findByBookingId(booking.getId())
+                .map(PaymentResponse::from)
+                .orElseGet(() -> createPayment(booking, request.depositorName()));
+    }
+
+    public PaymentResponse getPayment(User customer, Long paymentId) {
+        Payment payment = paymentRepository.findByIdAndCustomer(paymentId, customer)
+                .orElseThrow(() -> new NotFoundException("결제를 찾을 수 없습니다"));
+        return PaymentResponse.from(payment);
+    }
+
+    public PaymentResponse getPaymentByBooking(User customer, Long bookingId) {
+        Payment payment = paymentRepository.findByBookingId(bookingId)
+                .orElseThrow(() -> new NotFoundException("결제를 찾을 수 없습니다"));
+        validatePaymentCustomer(customer, payment);
+        return PaymentResponse.from(payment);
+    }
+
+    public Page<PaymentResponse> getMyPayments(User customer, Pageable pageable) {
+        return paymentRepository.findByCustomer(customer, pageable)
+                .map(PaymentResponse::from);
+    }
+
+    @Transactional
+    public PaymentResponse reportDeposit(User customer, Long paymentId, DepositReportRequest request) {
+        Payment payment = paymentRepository.findByIdAndCustomer(paymentId, customer)
+                .orElseThrow(() -> new NotFoundException("결제를 찾을 수 없습니다"));
+
+        validateDepositDue(payment);
+        payment.reportDeposit(request.depositorName(), request.memo());
+        return PaymentResponse.from(payment);
+    }
+
+    public Page<PaymentResponse> getPayments(PaymentStatus status, Pageable pageable) {
+        Page<Payment> payments = status == null
+                ? paymentRepository.findAll(pageable)
+                : paymentRepository.findByStatus(status, pageable);
+        return payments.map(PaymentResponse::from);
+    }
+
+    public PaymentResponse getPaymentForAdmin(Long paymentId) {
+        Payment payment = getPaymentEntity(paymentId);
+        return PaymentResponse.from(payment);
+    }
+
+    @Transactional
+    public PaymentResponse confirmDeposit(Long paymentId, PaymentConfirmRequest request) {
+        Payment payment = getPaymentEntity(paymentId);
+        PaymentConfirmRequest confirmRequest = request == null ? new PaymentConfirmRequest(null, null) : request;
+
+        if (payment.getBooking().getStatus() == BookingStatus.PENDING) {
+            payment.confirmDeposit(confirmRequest.confirmedAmount(), confirmRequest.adminMemo());
+            payment.getBooking().confirmPayment();
+            return PaymentResponse.from(payment);
+        }
+        if (payment.getBooking().getStatus() == BookingStatus.PAID) {
+            throw new BadRequestException("이미 결제 완료 처리된 예약입니다");
+        }
+        throw new BadRequestException("결제 확인 가능한 예약 상태가 아닙니다: " + payment.getBooking().getStatus().name());
+    }
+
+    @Transactional
+    public PaymentResponse cancelPayment(Long paymentId, PaymentCancelRequest request) {
+        Payment payment = getPaymentEntity(paymentId);
+        payment.cancel(request.reason());
+
+        if (payment.getBooking().getStatus() == BookingStatus.PENDING) {
+            payment.getBooking().cancel(request.reason());
+        }
+        return PaymentResponse.from(payment);
+    }
+
+    private PaymentResponse createPayment(Booking booking, String depositorName) {
+        if (booking.getStatus() != BookingStatus.PENDING) {
+            throw new BadRequestException("결제 대기 상태의 예약만 결제를 생성할 수 있습니다");
+        }
+
+        Payment payment = Payment.builder()
+                .booking(booking)
+                .customer(booking.getCustomer())
+                .counselor(booking.getCounselor())
+                .totalAmount(booking.getTotalPrice())
+                .platformFeeRate(bankTransferPaymentProperties.getPlatformFeeRate())
+                .bankName(bankTransferPaymentProperties.getBankName())
+                .accountNumber(bankTransferPaymentProperties.getAccountNumber())
+                .accountHolder(bankTransferPaymentProperties.getAccountHolder())
+                .depositDueAt(LocalDateTime.now().plusHours(bankTransferPaymentProperties.getDepositTimeoutHours()))
+                .depositorName(depositorName)
+                .build();
+
+        Payment savedPayment = paymentRepository.save(payment);
+        return PaymentResponse.from(savedPayment);
+    }
+
+    private Payment getPaymentEntity(Long paymentId) {
+        return paymentRepository.findById(paymentId)
+                .orElseThrow(() -> new NotFoundException("결제를 찾을 수 없습니다"));
+    }
+
+    private void validateBookingCustomer(User customer, Booking booking) {
+        if (!booking.getCustomer().getId().equals(customer.getId())) {
+            throw new UnauthorizedException("이 예약의 결제를 생성할 권한이 없습니다");
+        }
+    }
+
+    private void validatePaymentCustomer(User customer, Payment payment) {
+        if (!payment.getCustomer().getId().equals(customer.getId())) {
+            throw new UnauthorizedException("이 결제를 조회할 권한이 없습니다");
+        }
+    }
+
+    private void validateDepositDue(Payment payment) {
+        if (payment.getDepositDueAt().isBefore(LocalDateTime.now())) {
+            throw new BadRequestException("입금 기한이 만료된 결제입니다");
+        }
+    }
+}

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -103,5 +103,13 @@ firebase:
   client-x509-cert-url: ${FIREBASE_CLIENT_X509_CERT_URL}
   universe-domain: ${FIREBASE_UNIVERSE_DOMAIN}
 
+payment:
+  bank-transfer:
+    bank-name: ${PAYMENT_BANK_NAME:}
+    account-number: ${PAYMENT_ACCOUNT_NUMBER:}
+    account-holder: ${PAYMENT_ACCOUNT_HOLDER:KBuddy}
+    deposit-timeout-hours: ${PAYMENT_DEPOSIT_TIMEOUT_HOURS:24}
+    platform-fee-rate: ${PAYMENT_PLATFORM_FEE_RATE:15.00}
+
 server:
   port: 8080

--- a/src/test/java/com/example/kbuddy_backend/payment/service/PaymentServiceTest.java
+++ b/src/test/java/com/example/kbuddy_backend/payment/service/PaymentServiceTest.java
@@ -1,0 +1,210 @@
+package com.example.kbuddy_backend.payment.service;
+
+import com.example.kbuddy_backend.common.exception.UnauthorizedException;
+import com.example.kbuddy_backend.livechat.constant.BookingStatus;
+import com.example.kbuddy_backend.livechat.entity.Booking;
+import com.example.kbuddy_backend.livechat.repository.BookingRepository;
+import com.example.kbuddy_backend.payment.config.BankTransferPaymentProperties;
+import com.example.kbuddy_backend.payment.constant.PaymentStatus;
+import com.example.kbuddy_backend.payment.dto.request.BankTransferPaymentCreateRequest;
+import com.example.kbuddy_backend.payment.dto.request.DepositReportRequest;
+import com.example.kbuddy_backend.payment.dto.request.PaymentConfirmRequest;
+import com.example.kbuddy_backend.payment.dto.response.PaymentResponse;
+import com.example.kbuddy_backend.payment.entity.Payment;
+import com.example.kbuddy_backend.payment.repository.PaymentRepository;
+import com.example.kbuddy_backend.user.entity.User;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PaymentServiceTest {
+
+    @Mock
+    private PaymentRepository paymentRepository;
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    private BankTransferPaymentProperties bankTransferPaymentProperties;
+    private PaymentService paymentService;
+
+    private User customer;
+    private User counselor;
+    private Booking booking;
+
+    @BeforeEach
+    void setUp() {
+        bankTransferPaymentProperties = new BankTransferPaymentProperties();
+        bankTransferPaymentProperties.setBankName("KB Bank");
+        bankTransferPaymentProperties.setAccountNumber("123-456-789");
+        bankTransferPaymentProperties.setAccountHolder("KBuddy");
+        bankTransferPaymentProperties.setDepositTimeoutHours(24);
+        bankTransferPaymentProperties.setPlatformFeeRate(new BigDecimal("15.00"));
+
+        paymentService = new PaymentService(paymentRepository, bookingRepository, bankTransferPaymentProperties);
+
+        customer = User.builder()
+                .email("customer@kbuddy.com")
+                .username("customer")
+                .build();
+        ReflectionTestUtils.setField(customer, "id", 1L);
+
+        counselor = User.builder()
+                .email("counselor@kbuddy.com")
+                .username("counselor")
+                .build();
+        ReflectionTestUtils.setField(counselor, "id", 2L);
+
+        booking = Booking.builder()
+                .customer(customer)
+                .counselor(counselor)
+                .bookingStartUtc(LocalDateTime.of(2026, 5, 25, 10, 0))
+                .bookingEndUtc(LocalDateTime.of(2026, 5, 25, 10, 30))
+                .slotCount(1)
+                .totalPrice(20000)
+                .build();
+        ReflectionTestUtils.setField(booking, "id", 10L);
+    }
+
+    @Test
+    @DisplayName("무통장 입금 결제를 생성하면 입금 대기 상태와 수수료 스냅샷을 저장한다")
+    void createBankTransferPayment() {
+        given(bookingRepository.findById(10L)).willReturn(Optional.of(booking));
+        given(paymentRepository.findByBookingId(10L)).willReturn(Optional.empty());
+        given(paymentRepository.save(any(Payment.class))).willAnswer(invocation -> {
+            Payment payment = invocation.getArgument(0);
+            ReflectionTestUtils.setField(payment, "id", 100L);
+            return payment;
+        });
+
+        PaymentResponse response = paymentService.createBankTransferPayment(
+                customer,
+                new BankTransferPaymentCreateRequest(10L, "Hong Gil Dong")
+        );
+
+        assertEquals(100L, response.paymentId());
+        assertEquals(10L, response.bookingId());
+        assertEquals(PaymentStatus.AWAITING_DEPOSIT, response.status());
+        assertEquals(20000, response.totalAmount());
+        assertEquals(new BigDecimal("15.00"), response.platformFeeRate());
+        assertEquals(3000, response.platformFeeAmount());
+        assertEquals(17000, response.counselorSettlementAmount());
+        assertEquals("KB Bank", response.bankName());
+        assertEquals("123-456-789", response.accountNumber());
+        assertEquals("KBuddy", response.accountHolder());
+        assertEquals("Hong Gil Dong", response.depositorName());
+        assertNotNull(response.depositDueAt());
+    }
+
+    @Test
+    @DisplayName("예약자가 아닌 사용자는 결제를 생성할 수 없다")
+    void createBankTransferPaymentByOtherUser() {
+        User otherUser = User.builder()
+                .email("other@kbuddy.com")
+                .username("other")
+                .build();
+        ReflectionTestUtils.setField(otherUser, "id", 99L);
+
+        given(bookingRepository.findById(10L)).willReturn(Optional.of(booking));
+
+        assertThrows(UnauthorizedException.class, () ->
+                paymentService.createBankTransferPayment(
+                        otherUser,
+                        new BankTransferPaymentCreateRequest(10L, "Other")
+                )
+        );
+
+        verify(paymentRepository, never()).save(any(Payment.class));
+    }
+
+    @Test
+    @DisplayName("내담자가 입금 완료를 신고하면 입금 완료 신고 상태가 된다")
+    void reportDeposit() {
+        Payment payment = createPayment();
+        given(paymentRepository.findByIdAndCustomer(100L, customer)).willReturn(Optional.of(payment));
+
+        PaymentResponse response = paymentService.reportDeposit(
+                customer,
+                100L,
+                new DepositReportRequest("Hong Gil Dong", "입금했습니다")
+        );
+
+        assertEquals(PaymentStatus.DEPOSIT_REPORTED, response.status());
+        assertEquals("Hong Gil Dong", response.depositorName());
+        assertEquals("입금했습니다", response.customerMemo());
+        assertNotNull(response.depositReportedAt());
+    }
+
+    @Test
+    @DisplayName("관리자가 입금을 확인하면 결제와 예약이 모두 결제 완료 상태가 된다")
+    void confirmDeposit() {
+        Payment payment = createPayment();
+        payment.reportDeposit("Hong Gil Dong", "입금했습니다");
+        given(paymentRepository.findById(100L)).willReturn(Optional.of(payment));
+
+        PaymentResponse response = paymentService.confirmDeposit(
+                100L,
+                new PaymentConfirmRequest(20000, "관리자 확인")
+        );
+
+        assertEquals(PaymentStatus.PAID, response.status());
+        assertEquals(20000, response.confirmedAmount());
+        assertEquals("관리자 확인", response.adminMemo());
+        assertNotNull(response.paidAt());
+        assertEquals(BookingStatus.PAID, booking.getStatus());
+    }
+
+    @Test
+    @DisplayName("입금 확인 금액이 결제 금액과 다르면 결제 완료 처리하지 않는다")
+    void confirmDepositWithWrongAmount() {
+        Payment payment = createPayment();
+        given(paymentRepository.findById(100L)).willReturn(Optional.of(payment));
+
+        assertThrows(IllegalArgumentException.class, () ->
+                paymentService.confirmDeposit(
+                        100L,
+                        new PaymentConfirmRequest(19000, "금액 불일치")
+                )
+        );
+
+        assertEquals(PaymentStatus.AWAITING_DEPOSIT, payment.getStatus());
+        assertEquals(BookingStatus.PENDING, booking.getStatus());
+    }
+
+    private Payment createPayment() {
+        Payment payment = Payment.builder()
+                .booking(booking)
+                .customer(customer)
+                .counselor(counselor)
+                .totalAmount(booking.getTotalPrice())
+                .platformFeeRate(new BigDecimal("15.00"))
+                .bankName("KB Bank")
+                .accountNumber("123-456-789")
+                .accountHolder("KBuddy")
+                .depositDueAt(LocalDateTime.now().plusHours(24))
+                .depositorName("Hong Gil Dong")
+                .build();
+        ReflectionTestUtils.setField(payment, "id", 100L);
+        return payment;
+    }
+}


### PR DESCRIPTION
## Description (요약)
무통장 입금 기반 결제 도메인을 추가했습니다.  
내담자 입금 신고 및 관리자 입금 확인 플로우를 구현했습니다.

## Type of Change (변경사항목록)

- [ ] BUG FIX
- [x] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)
무통장 입금 결제 플로우 추가
- 예약 ID 기반 결제 생성
- 입금 계좌 정보 응답
- 내담자 입금 완료 신고
- 관리자 입금 확인
- 입금 확인 시 PaymentStatus.PAID 처리
- 입금 확인 시 기존 Booking.confirmPayment() 호출로 BookingStatus.PAID 전환

수수료 스냅샷 저장
- 기본 플랫폼 수수료율: 15.00%
- 결제 생성 시점에 플랫폼 수수료와 상담사 정산액 계산
- 예: 20,000원 결제 시 플랫폼 수수료 3,000원, 상담사 정산액 17,000원

결제 설정 추가
- PAYMENT_BANK_NAME
- PAYMENT_ACCOUNT_NUMBER
- PAYMENT_ACCOUNT_HOLDER
- PAYMENT_DEPOSIT_TIMEOUT_HOURS
- PAYMENT_PLATFORM_FEE_RATE

결제 서비스 테스트 추가
- 결제 생성
- 수수료 계산
- 권한 검증
- 입금 완료 신고
- 관리자 입금 확인
- 결제 금액 불일치 예외

## Screenshots (optional)


## Etc (비고)