### PR TITLE
[FIX] 관리자 페이지, 일반 유저 토큰 충돌 오류

### DIFF
--- a/src/main/java/com/example/kbuddy_backend/admin/config/AdminAuthCookie.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/config/AdminAuthCookie.java
@@ -1,0 +1,12 @@
+package com.example.kbuddy_backend.admin.config;
+
+public class AdminAuthCookie {
+
+    // 일반 사용자 쿠키 이름인 "refreshToken"과 구분
+    public static final String ADMIN_TOKEN_NAME = "adminRefreshToken";
+    // 관리자 쿠키는 관리자 API 요청에만 전달되도록 범위 제한, 해당 경로 아래의 요청에만 쿠키 전달
+    public static final String ADMIN_TOKEN_PATH = "/kbuddy/v1/admin";
+
+    private AdminAuthCookie() {
+    }
+}

--- a/src/main/java/com/example/kbuddy_backend/admin/controller/AdminAuthController.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/controller/AdminAuthController.java
@@ -4,6 +4,7 @@ import com.example.kbuddy_backend.admin.dto.request.AdminLoginRequest;
 import com.example.kbuddy_backend.admin.service.AdminAuthService;
 import com.example.kbuddy_backend.auth.dto.response.AccessTokenAndRefreshTokenResponse;
 import com.example.kbuddy_backend.auth.dto.response.AccessTokenResponse;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
@@ -15,6 +16,8 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import static com.example.kbuddy_backend.admin.config.AdminAuthCookie.*;
 
 @RestController
 @RequestMapping("/kbuddy/v1/admin")
@@ -43,11 +46,22 @@ public class AdminAuthController {
     }
 
     private void setRefreshTokenInCookie(HttpServletResponse response, AccessTokenAndRefreshTokenResponse token) {
-        jakarta.servlet.http.Cookie refreshTokenCookie = new jakarta.servlet.http.Cookie("refreshToken", token.refreshToken());
-        refreshTokenCookie.setPath("/");
-        refreshTokenCookie.setSecure(true);
-        refreshTokenCookie.setHttpOnly(true);
-        refreshTokenCookie.setMaxAge(refreshTokenExpiration);
-        response.addCookie(refreshTokenCookie);
+        /*
+         * 일반 사용자 refresh token과 관리자 refresh token이
+         * 서로 덮어쓰거나 잘못 사용되는 것을 방지합니다.
+         */
+        Cookie cookie = new Cookie(ADMIN_TOKEN_NAME, token.refreshToken());
+        // 관리자 API 요청에만 이 쿠키가 전송됩니다.
+        cookie.setPath(ADMIN_TOKEN_PATH);
+        // HTTPS 연결에서만 쿠키를 전송합니다.
+        cookie.setSecure(true);
+        /*
+         * JavaScript에서 document.cookie로 읽을 수 없도록 합니다.
+         * 토큰 탈취 위험을 줄이기 위한 설정입니다.
+         */
+        cookie.setHttpOnly(true);
+        // refresh token 만료 시간과 쿠키 만료 시간을 맞춥니다.
+        cookie.setMaxAge(refreshTokenExpiration);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/admin/service/AdminAuthService.java
+++ b/src/main/java/com/example/kbuddy_backend/admin/service/AdminAuthService.java
@@ -20,6 +20,8 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.stereotype.Service;
 
+import static com.example.kbuddy_backend.admin.config.AdminAuthCookie.ADMIN_TOKEN_NAME;
+
 @Service
 @RequiredArgsConstructor
 public class AdminAuthService {
@@ -62,10 +64,16 @@ public class AdminAuthService {
         if (request.getCookies() == null) {
             throw new TokenNotFoundException();
         }
-        Optional<String> refreshToken = Arrays.stream(request.getCookies())
-                .filter(cookie -> "refreshToken".equals(cookie.getName()))
+        /*
+         * 기존에는 "refreshToken"을 찾았기 때문에
+         * 일반 사용자 토큰도 선택될 수 있었습니다.
+         *
+         * 변경 후에는 "adminRefreshToken"만 찾습니다.
+         */
+        return Arrays.stream(request.getCookies())
+                .filter(cookie -> ADMIN_TOKEN_NAME.equals(cookie.getName()))
                 .map(Cookie::getValue)
-                .findFirst();
-        return refreshToken.orElseThrow(TokenNotFoundException::new);
+                .findFirst()
+                .orElseThrow(TokenNotFoundException::new);
     }
 }

--- a/src/main/java/com/example/kbuddy_backend/common/config/SecurityConfig.java
+++ b/src/main/java/com/example/kbuddy_backend/common/config/SecurityConfig.java
@@ -1,6 +1,5 @@
 package com.example.kbuddy_backend.common.config;
 
-import com.example.kbuddy_backend.admin.filter.AdminBasicAuthFilter;
 import com.example.kbuddy_backend.auth.config.JwtAccessDeniedHandler;
 import com.example.kbuddy_backend.auth.config.JwtAuthenticationEntryPoint;
 import com.example.kbuddy_backend.auth.config.JwtFilter;
@@ -28,7 +27,6 @@ public class SecurityConfig {
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
     private final JwtTokenProvider tokenProvider;
-    private final AdminBasicAuthFilter adminBasicAuthFilter;
 
     //시큐리티를 적용하지 않을 리소스
     @Bean
@@ -49,7 +47,6 @@ public class SecurityConfig {
                         .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .headers(header -> header.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
                 .addFilterBefore(new JwtFilter(tokenProvider), UsernamePasswordAuthenticationFilter.class)
-                .addFilterBefore(adminBasicAuthFilter, JwtFilter.class)
                 .exceptionHandling(exceptionHandling -> {
                     exceptionHandling
                             .authenticationEntryPoint(jwtAuthenticationEntryPoint)
@@ -58,7 +55,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests(authorizeRequests ->
                         authorizeRequests
                                 .requestMatchers("/kbuddy/v1/admin/login", "/kbuddy/v1/admin/refresh").permitAll()
-                                .requestMatchers("/admin/**").hasRole("ADMIN")
+                                .requestMatchers("/kbuddy/v1/admin/**").hasRole("ADMIN")
                                 .requestMatchers("/kbuddy/v1/auth/password","/kbuddy/v1/auth/authentication","/kbuddy/v1/auth/account").authenticated()
                                 .requestMatchers("/kbuddy/v1/auth/**","/actuator/health","/ws-stomp/**","/ws-stomp").permitAll()
                                 .anyRequest().authenticated());

--- a/src/test/java/com/example/kbuddy_backend/common/MockedServiceClassBeanRegister.java
+++ b/src/test/java/com/example/kbuddy_backend/common/MockedServiceClassBeanRegister.java
@@ -3,6 +3,7 @@ package com.example.kbuddy_backend.common;
 import static org.mockito.Mockito.mock;
 import static org.springframework.beans.factory.support.BeanDefinitionBuilder.rootBeanDefinition;
 
+import com.example.kbuddy_backend.livechat.service.CounselorProfileService;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.beans.BeansException;
@@ -39,6 +40,17 @@ public class MockedServiceClassBeanRegister implements BeanDefinitionRegistryPos
         provider.addIncludeFilter(new AnnotationTypeFilter(Service.class));
         return provider.findCandidateComponents("com.example.kbuddy_backend")
                 .stream()
+                /*
+                 * CounselorProfileService에는 @PersistenceContext EntityManager가 있습니다.
+                 *
+                 * @WebMvcTest는 JPA의 EntityManagerFactory를 생성하지 않으므로,
+                 * 기존 방식으로 이 Service를 Bean 등록하면 테스트 Context가 실패합니다.
+                 *
+                 * 프로덕션 Service는 변경하지 않고,
+                 * 공통 MVC 테스트의 자동 Service 등록 대상에서만 제외합니다.
+                 */
+                .filter(beanDefinition ->
+                        !CounselorProfileService.class.getName().equals(beanDefinition.getBeanClassName()))
                 .map(BeanDefinition::getBeanClassName)
                 .collect(Collectors.toSet());
     }

--- a/src/test/java/com/example/kbuddy_backend/common/WebMVCTest.java
+++ b/src/test/java/com/example/kbuddy_backend/common/WebMVCTest.java
@@ -3,6 +3,7 @@ package com.example.kbuddy_backend.common;
 import com.example.kbuddy_backend.auth.token.JwtTokenProvider;
 import com.example.kbuddy_backend.auth.token.TokenProvider;
 import com.example.kbuddy_backend.common.config.SecurityConfig;
+import com.example.kbuddy_backend.livechat.service.CounselorProfileService;
 import com.example.kbuddy_backend.user.repository.UserRepository;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,6 +23,16 @@ import org.springframework.web.bind.annotation.RestController;
                 @ComponentScan.Filter(type = FilterType.ASSIGNABLE_TYPE, classes = SecurityConfig.class) })
 @Import({ JwtTokenProvider.class, MockedServiceClassBeanRegister.class })
 public abstract class WebMVCTest {
+
+    /*
+     * CounselorController가 CounselorProfileService를 요구하므로
+     * Service를 완전히 제거하면 의존성 주입 오류가 발생합니다.
+     *
+     * Spring Boot의 @MockBean으로 대체하면 Controller가 요구하는 Bean은 존재하지만,
+     * 실제 Service의 @PersistenceContext EntityManager는 주입하지 않습니다.
+     */
+    @MockBean
+    protected CounselorProfileService counselorProfileService;
 
     @Autowired
     protected MockMvc mockMvc;


### PR DESCRIPTION
## Description (요약)

## 원인: 일반 사용자와 관리자가 같은 refreshToken 쿠키를 공유한다.

일반 로그인도 refreshToken을 Path=/로 저장

- UserAuthController.java(line 171)

```java
private void setRefreshTokenInCookie(HttpServletResponse response, AccessTokenAndRefreshTokenResponse token) {
        Cookie refreshTokenCookie = new Cookie("refreshToken", token.refreshToken());
        refreshTokenCookie.setPath("/");
        refreshTokenCookie.setHttpOnly(true);
        refreshTokenCookie.setMaxAge(refreshTokenExpiration);
        response.addCookie(refreshTokenCookie);
    }
```

관리자 로그인도 같은 이름과 경로로 덮어씁니다.

- AdminAuthController.java(line 45)

```java
private void setRefreshTokenInCookie(HttpServletResponse response, AccessTokenAndRefreshTokenResponse token) {
        jakarta.servlet.http.Cookie refreshTokenCookie = new jakarta.servlet.http.Cookie("refreshToken", token.refreshToken());
        refreshTokenCookie.setPath("/");
        refreshTokenCookie.setSecure(true);
        refreshTokenCookie.setHttpOnly(true);
        refreshTokenCookie.setMaxAge(refreshTokenExpiration);
        response.addCookie(refreshTokenCookie);
    }
```

/admin 진입 시 배포 프런트는 관리자 refresh API를 자동 호출합니다.

이때 일반 사용자의 refresh token이 전달되고, 서버는 ROLE_ADMIN 이 아니라는 이유로 거부

- AdminAuthService.java(line 47)

```java
public AccessTokenResponse refreshAccessToken(HttpServletRequest request) {
        String refreshToken = extractRefreshToken(request);
        if (!jwtTokenProvider.validateToken(refreshToken)) {
            throw new UnauthorizedException("유효하지 않은 refresh token입니다.");
        }
        String role = jwtTokenProvider.getUserRole(refreshToken);
        if (role == null || !role.contains(ADMIN_ROLE)) {
            throw new UnauthorizedException("관리자 권한이 없습니다.");
        }
        Authentication authentication = jwtTokenProvider.getAuthentication(refreshToken);
        TokenResponse accessToken = jwtTokenProvider.createAccessToken(authentication);
        return AccessTokenResponse.of(accessToken.token(), jwtTokenProvider.getAccessTokenExpiryDuration());
    }
```

## 추가 결함

실제 관리자 API는 /kbuddy/v1/admin/** 인데, 권한 검사는 /admin/** 에만 적용됩니다.

```java
.requestMatchers("/kbuddy/v1/admin/login", "/kbuddy/v1/admin/refresh").permitAll()
                                .requestMatchers("/admin/**").hasRole("ADMIN")
```

AdminBasicAuthFilter 도 /admin 만 검사하므로 실제 관리자 API 에는 동작하지 않음

```java
@Override
    protected boolean shouldNotFilter(HttpServletRequest request) {
        final String uri = request.getRequestURI();
        return uri == null || !uri.startsWith("/admin")
                || "/admin/login".equals(uri)
                || "/admin/refresh".equals(uri)
                || "/kbuddy/v1/admin/login".equals(uri);
    }
```

## 수정 계획

1. 관리자 쿠키를 adminRefreshToken 처럼 별도 이름으로 분리
2. /kbuddy/v1/admin/**에 ROLE_ADMIN 권한 적용
3. 현재 JWT 관리자 로그인과 중복되는 AdminBasicAuthFiler 정리
4. 일반 사용자 쿠키로 관리자 refresh → 401, 관리자 쿠키 → 200, 일반 JWT로 관리자 API → 403 테스트 추가

## Type of Change (변경사항목록)

- [x] BUG FIX
- [ ] NEW FEATURE
- [ ] DELETING UNNECESSARY FEATURES
- [ ] DOCUMENTATION
- [ ] Etc..(하단에 Change 내용 작성)


## Test Environment (테스팅 환경)


## Major Changes (주요 변경사항)


## Screenshots (optional)


## Etc (비고)